### PR TITLE
Make CBL Spats worth 0 points

### DIFF
--- a/clash-lib/src/game_state.rs
+++ b/clash-lib/src/game_state.rs
@@ -7,7 +7,6 @@ use crate::PlayerId;
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct SpatulaState {
-    pub collection_count: u8,
     pub collection_vec: Vec<PlayerId>,
 }
 

--- a/clash-server/src/lobby/lobby_actor.rs
+++ b/clash-server/src/lobby/lobby_actor.rs
@@ -1,5 +1,4 @@
 use bfbb::{Level, Spatula};
-use clash_lib::game_state::SpatulaState;
 use clash_lib::lobby::{GamePhase, LobbyOptions, NetworkedLobby};
 use clash_lib::net::{Item, LobbyMessage, Message};
 use clash_lib::player::{NetworkedPlayer, PlayerOptions};
@@ -352,7 +351,7 @@ impl LobbyActor {
                         .shared
                         .options
                         .spat_scores
-                        .get(state.collection_vec.len() - 1 as usize)
+                        .get(state.collection_vec.len() - 1)
                         .unwrap_or(&0);
                 }
 

--- a/clash-server/src/lobby/lobby_actor.rs
+++ b/clash-server/src/lobby/lobby_actor.rs
@@ -322,16 +322,11 @@ impl LobbyActor {
 
         match item {
             Item::Spatula(spat) => {
-                let state = self
-                    .shared
-                    .game_state
-                    .spatulas
-                    .entry(spat)
-                    .or_insert_with(SpatulaState::default);
+                let state = self.shared.game_state.spatulas.entry(spat).or_default();
 
                 // This can happen in rare situations where the player colllected an exhausted spatula
                 // before receiving the lobby update that exhausted it. We should just ignore this case
-                if state.collection_count == self.shared.options.tier_count {
+                if state.collection_vec.len() == self.shared.options.tier_count.into() {
                     log::info!(
                         "Player {player_id:#X} tried to collect exhausted spatula {spat:?}.",
                     );
@@ -342,25 +337,23 @@ impl LobbyActor {
                     return Err(LobbyError::InvalidAction(player_id));
                 }
 
-                player.score += self
-                    .shared
-                    .options
-                    .spat_scores
-                    .get(state.collection_count as usize)
-                    .unwrap_or(&0);
-
-                state
-                    .collection_vec
-                    .insert(state.collection_count as usize, player_id);
+                state.collection_vec.push(player_id);
                 log::info!(
                     "Player {player_id:#X} collected {spat:?} with tier {:?}",
-                    state.collection_count
+                    state.collection_vec.len()
                 );
-
-                state.collection_count += 1;
 
                 if spat == Spatula::TheSmallShallRuleOrNot {
                     self.stop_game();
+                    return Ok(());
+                }
+                if spat != Spatula::KahRahTae {
+                    player.score += self
+                        .shared
+                        .options
+                        .spat_scores
+                        .get(state.collection_vec.len() - 1 as usize)
+                        .unwrap_or(&0);
                 }
 
                 let message = Message::Lobby(LobbyMessage::GameLobbyInfo {
@@ -569,6 +562,15 @@ mod test {
             Err(LobbyError::PlayerInvalid(1337))
         );
 
+        // CBL Spats are worth 0 points
+        assert!(lobby
+            .player_collected_item(0, Item::Spatula(Spatula::KahRahTae))
+            .is_ok());
+        assert!(lobby
+            .player_collected_item(0, Item::Spatula(Spatula::TheSmallShallRuleOrNot))
+            .is_ok());
+        assert_eq!(lobby.shared.players.get(&0).unwrap().score, 0);
+
         // Collecting a spatula first grants highest score
         assert!(lobby
             .player_collected_item(0, Item::Spatula(Spatula::SpongebobsCloset))
@@ -656,7 +658,8 @@ mod test {
                 .spatulas
                 .get(&Spatula::CowaBungee)
                 .unwrap()
-                .collection_count,
+                .collection_vec
+                .len(),
             1
         );
 

--- a/clash/src/game/clash_game.rs
+++ b/clash/src/game/clash_game.rs
@@ -80,7 +80,7 @@ impl GameMode for ClashGame {
             }
 
             if let Some(spat_ref) = lobby.game_state.spatulas.get_mut(&spat) {
-                if spat_ref.collection_count != lobby.options.tier_count {
+                if spat_ref.collection_vec.len() != lobby.options.tier_count.into() {
                     interface.unlock_task(spat)?;
                 } else {
                     // Sync collected spatulas

--- a/clash/src/gui/lobby/tracker.rs
+++ b/clash/src/gui/lobby/tracker.rs
@@ -46,7 +46,7 @@ impl<'a> Widget for Tracker<'a> {
             // TODO: issue #57, Make spatula gold if locally collected and grayed out if unavailable
             let color = if spat_state.collection_vec.contains(&self.local_player) {
                 GOLD
-            } else if spat_state.collection_count == self.lobby.options.tier_count {
+            } else if spat_state.collection_vec.len() == self.lobby.options.tier_count.into() {
                 DISABLED
             } else {
                 SILVER


### PR DESCRIPTION
Closes #91

@999gary Open Question: This continues to sync the menu tasks for CBL with the same rules as all other spats. Do we want to prevent syncing the task status as well? That would mean that all players have to enter the lab through the chum bucket door. I'm not sure that it matters though, certainly not in a close game where you can't afford to wait for the warp to unlock.