### PR TITLE
Finish Tracker UI for Tiered Spatula Gameplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full Linux support
 - Networking Improvements
 - "Tiered Spatula" Gameplay update. Points awarded for a spatula depends on how many times it was collected previously.
+- Added local App Settings menu.
+- Added spatula icons to the tracker. These can be toggled on/off in the App Settings menu.
 
 ### Fixed
 

--- a/clash/src/gui/arc.rs
+++ b/clash/src/gui/arc.rs
@@ -1,26 +1,20 @@
-use eframe::epaint::{pos2, Color32, CubicBezierShape, Pos2, Shape, Stroke};
+use std::ops::Range;
+
+use eframe::epaint::{pos2, Color32, CubicBezierShape, Pos2, Shape, Stroke, Vec2};
 
 pub struct ArcShape {
     pub center: Pos2,
     pub radius: f32,
-    pub start_angle: f32,
-    pub end_angle: f32,
+    pub angle: Range<f32>,
     pub stroke: Stroke,
 }
 
 impl ArcShape {
-    pub fn new(
-        center: Pos2,
-        radius: f32,
-        start_angle: f32,
-        end_angle: f32,
-        stroke: impl Into<Stroke>,
-    ) -> Self {
+    pub fn new(center: Pos2, radius: f32, angle: Range<f32>, stroke: impl Into<Stroke>) -> Self {
         Self {
             center,
             radius,
-            start_angle,
-            end_angle,
+            angle,
             stroke: stroke.into(),
         }
     }
@@ -28,40 +22,47 @@ impl ArcShape {
 
 impl From<ArcShape> for Shape {
     fn from(arc: ArcShape) -> Self {
-        if arc.start_angle == arc.end_angle {
+        if arc.angle.is_empty() {
             return Shape::Noop;
         }
 
         let ArcShape {
             center,
             radius,
-            start_angle,
-            end_angle,
+            angle,
             stroke,
         } = arc;
-        let angle = end_angle - start_angle;
-        let k = (4. / 3.) * f32::tan(angle / 4.);
-        let srt_x = f32::cos(start_angle);
-        let srt_y = f32::sin(start_angle);
-        let end_x = f32::cos(end_angle);
-        let end_y = f32::sin(end_angle);
-
-        let start = pos2(radius * srt_x, radius * srt_y);
-        let ctrl_1 = pos2(radius * (srt_x - k * srt_y), radius * (srt_y + k * srt_x));
-        let ctrl_2 = pos2(radius * (end_x + k * end_y), radius * (end_y - k * end_x));
-        let end = pos2(radius * end_x, radius * end_y);
 
         let center = center.to_vec2();
         Shape::CubicBezier(CubicBezierShape::from_points_stroke(
-            [
-                start + center,
-                ctrl_1 + center,
-                ctrl_2 + center,
-                end + center,
-            ],
+            approx_arc(center, radius, angle),
             false,
             Color32::TRANSPARENT,
             stroke,
         ))
     }
+}
+
+/// Given the center and radius of a circle and a range representing the starting and ending angle of an arc of that circle,
+/// calculate the points of a cubic bezier curve approximating the arc.
+fn approx_arc(center: Vec2, radius: f32, angle: Range<f32>) -> [Pos2; 4] {
+    // Calculate the start end points relative to points on a unit-circle
+    let srt_x = f32::cos(angle.start);
+    let srt_y = f32::sin(angle.start);
+    let end_x = f32::cos(angle.end);
+    let end_y = f32::sin(angle.end);
+
+    // Calculate the position of those points on the screen.
+    let start = pos2(radius * srt_x, radius * srt_y) + center;
+    let end = pos2(radius * end_x, radius * end_y) + center;
+
+    // Calculate the control points of the bezier curve
+    // The math behind this is described here: https://pomax.github.io/bezierinfo/#circles_cubic,
+    // slightly adjusted to account for arcs that don't begin at angle 0
+    let angle = angle.end - angle.start;
+    let k = (4. / 3.) * f32::tan(angle / 4.);
+    let ctrl_1 = pos2(radius * (srt_x - k * srt_y), radius * (srt_y + k * srt_x)) + center;
+    let ctrl_2 = pos2(radius * (end_x + k * end_y), radius * (end_y - k * end_x)) + center;
+
+    [start, ctrl_1, ctrl_2, end]
 }

--- a/clash/src/gui/arc.rs
+++ b/clash/src/gui/arc.rs
@@ -1,0 +1,67 @@
+use eframe::epaint::{pos2, Color32, CubicBezierShape, Pos2, Shape, Stroke};
+
+pub struct ArcShape {
+    pub center: Pos2,
+    pub radius: f32,
+    pub start_angle: f32,
+    pub end_angle: f32,
+    pub stroke: Stroke,
+}
+
+impl ArcShape {
+    pub fn new(
+        center: Pos2,
+        radius: f32,
+        start_angle: f32,
+        end_angle: f32,
+        stroke: impl Into<Stroke>,
+    ) -> Self {
+        Self {
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            stroke: stroke.into(),
+        }
+    }
+}
+
+impl From<ArcShape> for Shape {
+    fn from(arc: ArcShape) -> Self {
+        if arc.start_angle == arc.end_angle {
+            return Shape::Noop;
+        }
+
+        let ArcShape {
+            center,
+            radius,
+            start_angle,
+            end_angle,
+            stroke,
+        } = arc;
+        let angle = end_angle - start_angle;
+        let k = (4. / 3.) * f32::tan(angle / 4.);
+        let srt_x = f32::cos(start_angle);
+        let srt_y = f32::sin(start_angle);
+        let end_x = f32::cos(end_angle);
+        let end_y = f32::sin(end_angle);
+
+        let start = pos2(radius * srt_x, radius * srt_y);
+        let ctrl_1 = pos2(radius * (srt_x - k * srt_y), radius * (srt_y + k * srt_x));
+        let ctrl_2 = pos2(radius * (end_x + k * end_y), radius * (end_y - k * end_x));
+        let end = pos2(radius * end_x, radius * end_y);
+
+        let center = center.to_vec2();
+        Shape::CubicBezier(CubicBezierShape::from_points_stroke(
+            [
+                start + center,
+                ctrl_1 + center,
+                ctrl_2 + center,
+                end + center,
+            ],
+            false,
+            Color32::TRANSPARENT,
+            stroke,
+        ))
+    }
+}

--- a/clash/src/gui/clash.rs
+++ b/clash/src/gui/clash.rs
@@ -145,11 +145,10 @@ impl App for Clash {
 
 impl Clash {
     fn app_settings(&mut self, ui: &mut Ui) {
-        let mut use_icons = self.state.use_icons.get();
         ui.add_option(
             "Use icons for spatula tracker",
-            &mut use_icons,
-            |&use_icons| {
+            self.state.use_icons.get(),
+            |use_icons| {
                 self.state.use_icons.set(use_icons);
             },
         );

--- a/clash/src/gui/clash.rs
+++ b/clash/src/gui/clash.rs
@@ -12,6 +12,8 @@ use crate::gui::main_menu::MainMenu;
 use crate::gui::state::State;
 use crate::gui::PADDING;
 
+use super::UiExt;
+
 pub struct Clash {
     state: Rc<State>,
     settings_open: bool,
@@ -144,8 +146,13 @@ impl App for Clash {
 impl Clash {
     fn app_settings(&mut self, ui: &mut Ui) {
         let mut use_icons = self.state.use_icons.get();
-        ui.checkbox(&mut use_icons, "Use icons for spatula tracker");
-        self.state.use_icons.set(use_icons);
+        ui.add_option(
+            "Use icons for spatula tracker",
+            &mut use_icons,
+            |&use_icons| {
+                self.state.use_icons.set(use_icons);
+            },
+        );
         if ui.button("Close").clicked() {
             self.settings_open = false;
         }

--- a/clash/src/gui/lobby/mod.rs
+++ b/clash/src/gui/lobby/mod.rs
@@ -128,7 +128,7 @@ impl App for Game {
                     }
                 }
                 GamePhase::Playing => {
-                    Tracker::new(&self.lobby, self.local_player_id).ui(ui);
+                    Tracker::new(&self.state, &self.lobby, self.local_player_id).ui(ui);
                 }
                 GamePhase::Finished => todo!(),
             }

--- a/clash/src/gui/lobby/mod.rs
+++ b/clash/src/gui/lobby/mod.rs
@@ -176,7 +176,7 @@ impl Game {
                     .get_or_insert_with(|| self.lobby.options.clone())
                     .tier_count = n;
             })
-            .on_hover_text("Number of times a spatula can be collectd before it's disabled");
+            .on_hover_text("Number of times a spatula can be collected before it's disabled");
 
             ui.add_option("Scores", self.scores.as_mut_slice(), |(i, x)| {
                 updated_options

--- a/clash/src/gui/lobby/mod.rs
+++ b/clash/src/gui/lobby/mod.rs
@@ -206,7 +206,11 @@ impl Game {
                 .on_disabled_hover_text(format!(
                     "Waiting on: {}",
                     intersperse(
-                        self.lobby.players.values().map(|p| p.options.name.as_str()),
+                        self.lobby
+                            .players
+                            .values()
+                            .filter(|p| !p.ready_to_start)
+                            .map(|p| p.options.name.as_str()),
                         ", "
                     )
                     .collect::<String>()

--- a/clash/src/gui/lobby/mod.rs
+++ b/clash/src/gui/lobby/mod.rs
@@ -154,8 +154,7 @@ impl Game {
     fn options_controls(&mut self, ui: &mut Ui) {
         let mut updated_options = None;
 
-        let mut ng_plus = self.lobby.options.ng_plus;
-        ui.add_option("New Game+", &mut ng_plus, |&x| {
+        ui.add_option("New Game+", self.lobby.options.ng_plus, |x| {
             updated_options
                 .get_or_insert_with(|| self.lobby.options.clone())
                 .ng_plus = x;
@@ -164,7 +163,7 @@ impl Game {
             "All players start the game with the Bubble Bowl and Cruise Missile unlocked.",
         );
 
-        ui.add_option("Lab Door Cost", &mut self.lab_door_cost, |&n| {
+        ui.add_option("Lab Door Cost", &mut self.lab_door_cost, |n| {
             updated_options
                 .get_or_insert_with(|| self.lobby.options.clone())
                 .lab_door_cost = n;
@@ -172,14 +171,14 @@ impl Game {
         .on_hover_text("Spatulas required to enter Chum Bucket Labs");
 
         ui.collapsing("Debug Options", |ui| {
-            ui.add_option("Tier Count", &mut self.tier_count, |&n| {
+            ui.add_option("Tier Count", &mut self.tier_count, |n| {
                 updated_options
                     .get_or_insert_with(|| self.lobby.options.clone())
                     .tier_count = n;
             })
             .on_hover_text("Number of times a spatula can be collectd before it's disabled");
 
-            ui.add_option("Scores", self.scores.as_mut_slice(), |&(i, x)| {
+            ui.add_option("Scores", self.scores.as_mut_slice(), |(i, x)| {
                 updated_options
                     .get_or_insert_with(|| self.lobby.options.clone())
                     .spat_scores[i] = x;

--- a/clash/src/gui/lobby/mod.rs
+++ b/clash/src/gui/lobby/mod.rs
@@ -128,7 +128,7 @@ impl App for Game {
                     }
                 }
                 GamePhase::Playing => {
-                    ui.add(Tracker::new(&self.lobby, self.local_player_id));
+                    Tracker::new(&self.lobby, self.local_player_id).ui(ui);
                 }
                 GamePhase::Finished => todo!(),
             }

--- a/clash/src/gui/lobby/tracker.rs
+++ b/clash/src/gui/lobby/tracker.rs
@@ -130,8 +130,7 @@ impl Widget for SpatulaStatus<'_> {
                     ui.painter().add(ArcShape::new(
                         rect.center(),
                         radius + 2.,
-                        start,
-                        start + ang - pad,
+                        start..start + ang - pad,
                         (1., color),
                     ));
                 }

--- a/clash/src/gui/lobby/tracker.rs
+++ b/clash/src/gui/lobby/tracker.rs
@@ -11,7 +11,6 @@ use crate::gui::{arc::ArcShape, state::State};
 
 const GOLD: Color32 = Color32::from_rgb(0xd4, 0xaf, 0x37);
 const SILVER: Color32 = Color32::from_rgb(0xe0, 0xe0, 0xe0);
-const DISABLED: Color32 = Color32::from_rgb(0x3c, 0x3c, 0x3c);
 
 pub struct Tracker<'a> {
     state: &'a State,
@@ -86,19 +85,30 @@ impl Widget for SpatulaStatus<'_> {
         let (rect, response) =
             ui.allocate_exact_size(vec2(radius * 2., radius * 2.), Sense::hover());
 
-        let texture = if state.collection_vec.contains(&local_player)
-            || state.collection_vec.len() == lobby.options.tier_count.into()
-        {
-            &app_state.golden_spatula
+        if app_state.use_icons.get() {
+            let texture = if state.collection_vec.contains(&local_player)
+                || state.collection_vec.len() == lobby.options.tier_count.into()
+            {
+                &app_state.golden_spatula
+            } else {
+                &app_state.silver_spatula
+            };
+            ui.painter().add(Shape::image(
+                texture.id(),
+                rect,
+                Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
+                Color32::WHITE,
+            ));
         } else {
-            &app_state.silver_spatula
-        };
-        ui.painter().add(Shape::image(
-            texture.id(),
-            rect,
-            Rect::from_min_max(pos2(0.0, 0.0), pos2(1.0, 1.0)),
-            Color32::WHITE,
-        ));
+            let color = if state.collection_vec.contains(&local_player)
+                || state.collection_vec.len() == lobby.options.tier_count.into()
+            {
+                GOLD
+            } else {
+                SILVER
+            };
+            ui.painter().circle_filled(rect.center(), radius, color);
+        }
 
         match lobby.options.tier_count {
             1 => {

--- a/clash/src/gui/lobby/tracker.rs
+++ b/clash/src/gui/lobby/tracker.rs
@@ -1,9 +1,13 @@
-use bfbb::{IntoEnumIterator, Spatula};
+use std::f32::consts::PI;
+
+use bfbb::Spatula;
 use clash_lib::{game_state::SpatulaState, lobby::NetworkedLobby, PlayerId};
 use eframe::{
     egui::{Color32, Response, Sense, Ui, Widget},
-    epaint::Vec2,
+    epaint::vec2,
 };
+
+use crate::gui::arc::ArcShape;
 
 const GOLD: Color32 = Color32::from_rgb(0xd4, 0xaf, 0x37);
 const SILVER: Color32 = Color32::from_rgb(0xe0, 0xe0, 0xe0);
@@ -22,45 +26,94 @@ impl<'a> Tracker<'a> {
         }
     }
 }
-impl<'a> Widget for Tracker<'a> {
+impl<'a> Tracker<'a> {
+    pub fn ui(self, ui: &mut Ui) {
+        for x in 0..13 {
+            ui.horizontal(|ui| {
+                for y in 0..8 {
+                    if let Ok(spat) = Spatula::try_from((x, y)) {
+                        ui.add(SpatulaStatus::new(spat, self.local_player, self.lobby))
+                            .on_hover_text(format!("{spat:?}"));
+                    }
+                }
+            });
+        }
+    }
+}
+
+struct SpatulaStatus<'a> {
+    spat: Spatula,
+    local_player: PlayerId,
+    lobby: &'a NetworkedLobby,
+}
+
+impl<'a> SpatulaStatus<'a> {
+    fn new(spat: Spatula, local_player: PlayerId, lobby: &'a NetworkedLobby) -> Self {
+        Self {
+            spat,
+            local_player,
+            lobby,
+        }
+    }
+}
+
+impl Widget for SpatulaStatus<'_> {
     fn ui(self, ui: &mut Ui) -> Response {
-        let available_size = ui.available_size();
+        let Self {
+            spat,
+            local_player,
+            lobby,
+        } = self;
 
-        // Determine largest radius without overflowing bounds
-        let width_radius = (available_size.x - 8. * 7.) / 8. / 2.;
-        let height_radius = (available_size.y - 8. * 12.) / 13. / 2.;
-        let radius = f32::min(width_radius, height_radius);
-        let desired_size = Vec2::new(radius * 2. * 8. + (8. * 7.), radius * 2. * 13. + (8. * 12.));
-
+        let def = SpatulaState::default();
+        let state = self.lobby.game_state.spatulas.get(&spat).unwrap_or(&def);
+        let radius = 16.15;
         let (rect, response) =
-            ui.allocate_exact_size(desired_size, Sense::focusable_noninteractive());
+            ui.allocate_exact_size(vec2(radius * 2., radius * 2.), Sense::hover());
 
-        for spat in Spatula::iter() {
-            let spat_state = self
-                .lobby
-                .game_state
-                .spatulas
-                .get(&spat)
-                .unwrap_or(&SpatulaState::default())
-                .clone();
-            // TODO: issue #57, Make spatula gold if locally collected and grayed out if unavailable
-            let color = if spat_state.collection_vec.contains(&self.local_player) {
-                GOLD
-            } else if spat_state.collection_vec.len() == self.lobby.options.tier_count.into() {
-                DISABLED
-            } else {
-                SILVER
-            };
-            let (y, x) = spat.into();
-            ui.painter().circle_filled(
-                (
-                    x as f32 * (2. * radius + 8.) + rect.left_top().x + radius,
-                    y as f32 * (2. * radius + 8.) + rect.left_top().y + radius,
-                )
-                    .into(),
-                radius,
-                color,
-            )
+        let color = if state.collection_vec.contains(&local_player) {
+            GOLD
+        } else if state.collection_vec.len() == lobby.options.tier_count.into() {
+            DISABLED
+        } else {
+            SILVER
+        };
+        ui.painter()
+            .circle_filled(rect.center(), radius - 2., color);
+
+        match lobby.options.tier_count {
+            1 => {
+                let color = state
+                    .collection_vec
+                    .first()
+                    .and_then(|id| lobby.players.get(id))
+                    .map(|p| p.options.color)
+                    .map(|(r, g, b)| Color32::from_rgb(r, g, b))
+                    .unwrap_or(ui.style().visuals.widgets.inactive.bg_fill);
+                ui.painter()
+                    .circle_stroke(rect.center(), radius + 2., (1., color));
+            }
+            x => {
+                let ang = PI * 2. / x as f32;
+                let pad = f32::to_radians(10.0);
+                for i in 0..x {
+                    let color = state
+                        .collection_vec
+                        .get(usize::from(i))
+                        .and_then(|id| lobby.players.get(id))
+                        .map(|p| p.options.color)
+                        .map(|(r, g, b)| Color32::from_rgb(r, g, b))
+                        .unwrap_or(ui.style().visuals.widgets.inactive.bg_fill);
+                    let start = ang * i as f32 + pad / 2.;
+                    ui.painter().add(ArcShape::new(
+                        rect.center(),
+                        radius + 2.,
+                        start,
+                        start + ang - pad,
+                        (1., color),
+                    ));
+                }
+            }
         }
 
         response

--- a/clash/src/gui/lobby/tracker.rs
+++ b/clash/src/gui/lobby/tracker.rs
@@ -85,14 +85,14 @@ impl Widget for SpatulaStatus<'_> {
         let (rect, response) =
             ui.allocate_exact_size(vec2(radius * 2., radius * 2.), Sense::hover());
 
+        let (texture, color) = if state.collection_vec.contains(&local_player)
+            || state.collection_vec.len() == lobby.options.tier_count.into()
+        {
+            (&app_state.golden_spatula, GOLD)
+        } else {
+            (&app_state.silver_spatula, SILVER)
+        };
         if app_state.use_icons.get() {
-            let texture = if state.collection_vec.contains(&local_player)
-                || state.collection_vec.len() == lobby.options.tier_count.into()
-            {
-                &app_state.golden_spatula
-            } else {
-                &app_state.silver_spatula
-            };
             ui.painter().add(Shape::image(
                 texture.id(),
                 rect,
@@ -100,13 +100,6 @@ impl Widget for SpatulaStatus<'_> {
                 Color32::WHITE,
             ));
         } else {
-            let color = if state.collection_vec.contains(&local_player)
-                || state.collection_vec.len() == lobby.options.tier_count.into()
-            {
-                GOLD
-            } else {
-                SILVER
-            };
             ui.painter().circle_filled(rect.center(), radius, color);
         }
 

--- a/clash/src/gui/main_menu.rs
+++ b/clash/src/gui/main_menu.rs
@@ -126,7 +126,7 @@ impl App for MainMenu {
                         lobby_data
                             .network_sender
                             .try_send(NetCommand::Send(Message::GameJoin {
-                                lobby_id: *self.lobby_id.get_val().unwrap(),
+                                lobby_id: self.lobby_id.get_val().unwrap(),
                             }))
                             .unwrap();
                         lobby_data

--- a/clash/src/gui/mod.rs
+++ b/clash/src/gui/mod.rs
@@ -48,22 +48,22 @@ pub trait UiExt<'a, In: ?Sized, Out> {
     fn add_option(
         &mut self,
         label: impl Into<WidgetText>,
-        input: &'a mut In,
-        on_changed: impl FnMut(&Out) + 'a,
+        input: In,
+        on_changed: impl FnMut(Out) + 'a,
     ) -> Response;
 }
 
 impl<'a, In, Out> UiExt<'a, In, Out> for Ui
 where
-    In: 'a + ?Sized,
+    In: 'a,
     Out: 'a,
     OptionEditor<'a, In, Out>: Widget,
 {
     fn add_option(
         &mut self,
         text: impl Into<WidgetText>,
-        input: &'a mut In,
-        on_changed: impl FnMut(&Out) + 'a,
+        input: In,
+        on_changed: impl FnMut(Out) + 'a,
     ) -> Response {
         let editor = OptionEditor::new(text, input, on_changed);
         self.add(editor)

--- a/clash/src/gui/mod.rs
+++ b/clash/src/gui/mod.rs
@@ -1,12 +1,15 @@
 use clash_lib::{lobby::NetworkedLobby, PlayerId};
+use eframe::egui::{Response, Ui, Widget, WidgetText};
 use eframe::{run_native, IconData, NativeOptions};
 
 use self::clash::Clash;
+use self::option_editor::OptionEditor;
 
 mod arc;
 mod clash;
 mod lobby;
 mod main_menu;
+mod option_editor;
 mod state;
 mod val_text;
 
@@ -39,4 +42,30 @@ pub fn run() {
         window_options,
         Box::new(|cc| Box::new(Clash::new(cc))),
     );
+}
+
+pub trait UiExt<'a, In: ?Sized, Out> {
+    fn add_option(
+        &mut self,
+        label: impl Into<WidgetText>,
+        input: &'a mut In,
+        on_changed: impl FnMut(&Out) + 'a,
+    ) -> Response;
+}
+
+impl<'a, In, Out> UiExt<'a, In, Out> for Ui
+where
+    In: 'a + ?Sized,
+    Out: 'a,
+    OptionEditor<'a, In, Out>: Widget,
+{
+    fn add_option(
+        &mut self,
+        text: impl Into<WidgetText>,
+        input: &'a mut In,
+        on_changed: impl FnMut(&Out) + 'a,
+    ) -> Response {
+        let editor = OptionEditor::new(text, input, on_changed);
+        self.add(editor)
+    }
 }

--- a/clash/src/gui/mod.rs
+++ b/clash/src/gui/mod.rs
@@ -3,6 +3,7 @@ use eframe::{run_native, IconData, NativeOptions};
 
 use self::clash::Clash;
 
+mod arc;
 mod clash;
 mod lobby;
 mod main_menu;

--- a/clash/src/gui/option_editor.rs
+++ b/clash/src/gui/option_editor.rs
@@ -1,0 +1,67 @@
+use eframe::{
+    egui::{Response, Ui, Widget, WidgetText},
+    epaint::Color32,
+};
+
+use super::{val_text::ValText, UiExt};
+
+pub struct OptionEditor<'a, In: ?Sized, Out> {
+    label: WidgetText,
+    input: &'a mut In,
+    on_changed: Box<dyn FnMut(&Out) + 'a>,
+}
+
+impl<'a, In: ?Sized, Out> OptionEditor<'a, In, Out> {
+    pub fn new(
+        text: impl Into<WidgetText>,
+        input: &'a mut In,
+        changed: impl FnMut(&Out) + 'a,
+    ) -> Self {
+        Self {
+            label: text.into(),
+            input,
+            on_changed: Box::new(changed),
+        }
+    }
+}
+
+impl<'a, T> Widget for OptionEditor<'a, ValText<T>, T> {
+    fn ui(mut self, ui: &mut Ui) -> eframe::egui::Response {
+        ui.horizontal(|ui| {
+            if !self.input.is_valid() {
+                ui.style_mut().visuals.override_text_color = Some(Color32::DARK_RED);
+            }
+            ui.label(self.label);
+            if ui.text_edit_singleline(self.input).changed() && self.input.is_valid() {
+                if let Some(x) = self.input.get_val() {
+                    (self.on_changed)(x);
+                }
+            }
+        })
+        .response
+    }
+}
+
+impl<'a> Widget for OptionEditor<'a, bool, bool> {
+    fn ui(mut self, ui: &mut Ui) -> Response {
+        ui.horizontal(|ui| {
+            if ui.checkbox(self.input, self.label).changed() {
+                (self.on_changed)(self.input);
+            }
+        })
+        .response
+    }
+}
+
+impl<'a, T: Copy> Widget for OptionEditor<'a, [ValText<T>], (usize, T)> {
+    fn ui(mut self, ui: &mut Ui) -> Response {
+        ui.collapsing(self.label, |ui| {
+            for (i, input) in self.input.iter_mut().enumerate() {
+                ui.add_option(format!("Tier {}", i + 1), input, |&x| {
+                    (self.on_changed)(&(i, x))
+                });
+            }
+        })
+        .header_response
+    }
+}

--- a/clash/src/gui/state.rs
+++ b/clash/src/gui/state.rs
@@ -1,7 +1,7 @@
 use std::cell::Cell;
 
 use eframe::{
-    egui::Context,
+    egui::{Context, TextureFilter},
     epaint::{ColorImage, TextureHandle},
     App,
 };
@@ -12,6 +12,8 @@ pub type ErrorReceiver = std::sync::mpsc::Receiver<anyhow::Error>;
 pub struct State {
     next_app: Cell<Option<Box<dyn App>>>,
     pub logo: TextureHandle,
+    pub golden_spatula: TextureHandle,
+    pub silver_spatula: TextureHandle,
     pub error_sender: ErrorSender,
     pub error_receiver: ErrorReceiver,
 }
@@ -20,13 +22,28 @@ impl State {
     pub fn new(ctx: &Context) -> Self {
         let logo = ctx.load_texture(
             "logo",
-            load_image_from_memory(include_bytes!("../../res/logo.png")).unwrap(),
-            eframe::egui::TextureFilter::Linear,
+            load_image_from_memory(include_bytes!("../../res/logo.png"))
+                .expect("The image is in the binary."),
+            TextureFilter::Linear,
+        );
+        let golden_spatula = ctx.load_texture(
+            "golden spatula",
+            load_image_from_memory(include_bytes!("../../res/golden_spatula_60.gif"))
+                .expect("The image is in the binary"),
+            TextureFilter::Linear,
+        );
+        let silver_spatula = ctx.load_texture(
+            "silver spatula",
+            load_image_from_memory(include_bytes!("../../res/silver_spatula_60.gif"))
+                .expect("The image is in the binary."),
+            TextureFilter::Linear,
         );
         let (error_sender, error_receiver) = std::sync::mpsc::channel();
         Self {
             next_app: Cell::new(None),
             logo,
+            golden_spatula,
+            silver_spatula,
             error_sender,
             error_receiver,
         }

--- a/clash/src/gui/state.rs
+++ b/clash/src/gui/state.rs
@@ -14,6 +14,7 @@ pub struct State {
     pub logo: TextureHandle,
     pub golden_spatula: TextureHandle,
     pub silver_spatula: TextureHandle,
+    pub use_icons: Cell<bool>,
     pub error_sender: ErrorSender,
     pub error_receiver: ErrorReceiver,
 }
@@ -44,6 +45,7 @@ impl State {
             logo,
             golden_spatula,
             silver_spatula,
+            use_icons: Cell::new(true),
             error_sender,
             error_receiver,
         }

--- a/clash/src/gui/val_text.rs
+++ b/clash/src/gui/val_text.rs
@@ -13,7 +13,7 @@ pub struct ValText<T> {
     validator: Box<dyn Fn(&str) -> Option<T>>,
 }
 
-impl<T> ValText<T> {
+impl<T: Copy> ValText<T> {
     pub fn with_validator(validator: impl Fn(&str) -> Option<T> + 'static) -> Self {
         Self {
             text: Default::default(),
@@ -22,8 +22,8 @@ impl<T> ValText<T> {
         }
     }
 
-    pub fn get_val(&self) -> Option<&T> {
-        self.val.as_ref()
+    pub fn get_val(&self) -> Option<T> {
+        self.val
     }
 
     pub fn is_valid(&self) -> bool {


### PR DESCRIPTION
Extends the tracker to show the arc described in #57. The tracker was divided into a `SpatulaStatus` subwidget that handles drawing and placing itself rather than a single widget that draws all the spatulas. 

Additionally a new settings menu was implemented that allows toggling between drawing spatula icons or drawing circles for the tracker like before. This menu is accessed by a gear at the bottom right of the screen and is accessible from any other menu. It simply shows up on top of everything else and when closed the GUI returns to where it was previously.

For colored circles the `DISABLED` spatula color has been removed to match the in-game menu, as this is simpler to understand and matches the behavior of the icons and in-game menu, since we only have silver/gold spatulas.

Closes #57 

Images:

Updated bottom-bar 
![image](https://user-images.githubusercontent.com/3579314/194676083-a427ef9a-2ed1-415a-9c89-ab69eceab2e6.png)

Settings menu, can be closed by the "close" button or by clicking the gear again. (This styling will be updated later).
![image](https://user-images.githubusercontent.com/3579314/194676121-d856b094-8049-4fb6-871f-709f044e7a0e.png)

Tracker UI:
![image](https://user-images.githubusercontent.com/3579314/194676158-0f466341-0124-40c0-ad84-2b30ef2027a0.png)

Tracker UI (no icons):
![image](https://user-images.githubusercontent.com/3579314/194676174-7ce33c71-7288-4bbf-b64f-17812d427a84.png)
