### PR TITLE
Sleep the logic loop

### DIFF
--- a/clash/src/game/mod.rs
+++ b/clash/src/game/mod.rs
@@ -42,7 +42,7 @@ pub fn start_game(
         logic.update_from_network().unwrap();
         logic.update();
 
-        loop_helper.loop_start_s();
+        loop_helper.loop_sleep();
     }
 }
 


### PR DESCRIPTION
All the way back in https://github.com/BfBB-Clash/BfBB-Clash/commit/e7c00dd4d4cbf094aeb7e5c610ead3d42da19e39 the call to sleep the logic loop was mistakenly replaced, oops lol.