### PR TITLE
Allow non-host to see options

### DIFF
--- a/clash-lib/src/lobby.rs
+++ b/clash-lib/src/lobby.rs
@@ -36,6 +36,8 @@ pub struct NetworkedLobby {
     pub options: LobbyOptions,
     pub players: HashMap<PlayerId, NetworkedPlayer>,
     pub game_phase: GamePhase,
+    // TODO: Refactor this option out, we don't create a lobby until a player has connected to the server
+    //       so we should be able to specify them as the host. When the last player leaves we close the lobby.
     pub host_id: Option<PlayerId>,
 }
 

--- a/clash/src/gui/mod.rs
+++ b/clash/src/gui/mod.rs
@@ -65,7 +65,7 @@ where
         input: In,
         on_changed: impl FnMut(Out) + 'a,
     ) -> Response {
-        let editor = OptionEditor::new(text, input, on_changed);
+        let editor = OptionEditor::new(text, input, on_changed).enabled(true);
         self.add(editor)
     }
 }

--- a/clash/src/gui/option_editor.rs
+++ b/clash/src/gui/option_editor.rs
@@ -1,13 +1,14 @@
 use eframe::{
-    egui::{Response, Ui, Widget, WidgetText},
+    egui::{Checkbox, Response, TextEdit, Ui, Widget, WidgetText},
     epaint::Color32,
 };
 
-use super::{val_text::ValText, UiExt};
+use super::val_text::ValText;
 
 pub struct OptionEditor<'a, In, Out> {
     label: WidgetText,
     input: In,
+    enabled: bool,
     on_changed: Box<dyn FnMut(Out) + 'a>,
 }
 
@@ -16,8 +17,14 @@ impl<'a, In, Out> OptionEditor<'a, In, Out> {
         Self {
             label: text.into(),
             input,
+            enabled: true,
             on_changed: Box::new(changed),
         }
+    }
+
+    pub fn enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
     }
 }
 
@@ -28,7 +35,8 @@ impl<'a, T: Copy> Widget for OptionEditor<'a, &'a mut ValText<T>, T> {
                 ui.style_mut().visuals.override_text_color = Some(Color32::DARK_RED);
             }
             ui.label(self.label);
-            if ui.text_edit_singleline(self.input).changed() && self.input.is_valid() {
+            let res = ui.add_enabled(self.enabled, TextEdit::singleline(self.input));
+            if res.changed() && self.input.is_valid() {
                 if let Some(x) = self.input.get_val() {
                     (self.on_changed)(x);
                 }
@@ -41,7 +49,10 @@ impl<'a, T: Copy> Widget for OptionEditor<'a, &'a mut ValText<T>, T> {
 impl<'a> Widget for OptionEditor<'a, bool, bool> {
     fn ui(mut self, ui: &mut Ui) -> Response {
         ui.horizontal(|ui| {
-            if ui.checkbox(&mut self.input, self.label).changed() {
+            if ui
+                .add_enabled(self.enabled, Checkbox::new(&mut self.input, self.label))
+                .changed()
+            {
                 (self.on_changed)(self.input);
             }
         })
@@ -53,9 +64,12 @@ impl<'a, T: Copy> Widget for OptionEditor<'a, &'a mut [ValText<T>], (usize, T)> 
     fn ui(mut self, ui: &mut Ui) -> Response {
         ui.collapsing(self.label, |ui| {
             for (i, input) in self.input.iter_mut().enumerate() {
-                ui.add_option(format!("Tier {}", i + 1), input, |x| {
-                    (self.on_changed)((i, x))
-                });
+                ui.add(
+                    OptionEditor::new(format!("Tier {}", i + 1), input, |x| {
+                        (self.on_changed)((i, x))
+                    })
+                    .enabled(self.enabled),
+                );
             }
         })
         .header_response


### PR DESCRIPTION
Also moves the "Copy Lobby ID" button to always be available while in a lobby.