### PR TITLE
Write some game logic unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bfbb"
-version = "0.3.0-beta.0"
+version = "0.3.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743c7ce48bd28d46157dd85fb56b59822c479bb49f01a688ab02913ba23d3706"
+checksum = "a903c7f199ffe0bad672291b8749e8ac12a90556a8ab0d0f1008430a91141f97"
 dependencies = [
  "bytemuck",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [workspace.dependencies]
 anyhow = "1"
-bfbb = "0.3.0-beta.0"
+bfbb = "0.3.0-beta.1"
 clash_lib = { path = "crates/clash-lib" }
 env_logger = "0.9"
 log = "0.4"

--- a/crates/clash-lib/src/net/message.rs
+++ b/crates/clash-lib/src/net/message.rs
@@ -14,21 +14,33 @@ pub enum Message {
     GameHost,
     GameJoin { lobby_id: u32 },
     Lobby(LobbyMessage),
+    GameLobbyInfo { lobby: NetworkedLobby },
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+impl From<LobbyMessage> for Message {
+    fn from(msg: LobbyMessage) -> Self {
+        Self::Lobby(msg)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub enum LobbyMessage {
     PlayerOptions { options: PlayerOptions },
     PlayerCanStart(bool),
     GameBegin,
     GameEnd,
     GameOptions { options: LobbyOptions },
-    GameLobbyInfo { lobby: NetworkedLobby },
     GameCurrentLevel { level: Option<Level> },
     GameItemCollected { item: Item },
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub enum Item {
     Spatula(Spatula),
+}
+
+impl From<Spatula> for Item {
+    fn from(spat: Spatula) -> Self {
+        Self::Spatula(spat)
+    }
 }

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -234,7 +234,6 @@ impl Client {
                 self.lobby_handle.player_collected_item(item).await?;
             }
             LobbyMessage::GameEnd => todo!(),
-            LobbyMessage::GameLobbyInfo { lobby: _ } => todo!(),
         }
 
         Ok(())

--- a/crates/clash-server/src/lobby/lobby_actor.rs
+++ b/crates/clash-server/src/lobby/lobby_actor.rs
@@ -152,11 +152,9 @@ impl LobbyActor {
 
         self.reset_game();
         self.shared.game_phase = GamePhase::Playing;
-        let _ = self
-            .sender
-            .send(Message::Lobby(LobbyMessage::GameLobbyInfo {
-                lobby: self.shared.clone(),
-            }));
+        let _ = self.sender.send(Message::GameLobbyInfo {
+            lobby: self.shared.clone(),
+        });
         if self
             .sender
             .send(Message::Lobby(LobbyMessage::GameBegin))
@@ -173,11 +171,9 @@ impl LobbyActor {
 
     fn stop_game(&mut self) {
         self.shared.game_phase = GamePhase::Setup;
-        let _ = self
-            .sender
-            .send(Message::Lobby(LobbyMessage::GameLobbyInfo {
-                lobby: self.shared.clone(),
-            }));
+        let _ = self.sender.send(Message::GameLobbyInfo {
+            lobby: self.shared.clone(),
+        });
         if self
             .sender
             .send(Message::Lobby(LobbyMessage::GameEnd))
@@ -218,11 +214,9 @@ impl LobbyActor {
         // Subscribe early so that this player will receive the lobby update that adds them
         let recv = self.sender.subscribe();
 
-        let _ = self
-            .sender
-            .send(Message::Lobby(LobbyMessage::GameLobbyInfo {
-                lobby: self.shared.clone(),
-            }));
+        let _ = self.sender.send(Message::GameLobbyInfo {
+            lobby: self.shared.clone(),
+        });
 
         Ok(recv)
     }
@@ -244,11 +238,9 @@ impl LobbyActor {
         }
 
         // Update remaining clients of the change
-        let _ = self
-            .sender
-            .send(Message::Lobby(LobbyMessage::GameLobbyInfo {
-                lobby: self.shared.clone(),
-            }));
+        let _ = self.sender.send(Message::GameLobbyInfo {
+            lobby: self.shared.clone(),
+        });
 
         // Close the lobby after the last player leaves by closing our receiver.
         // This will cause the run loop to consume all remaining messages,
@@ -273,9 +265,9 @@ impl LobbyActor {
         options.color = player.options.color;
         player.options = options;
 
-        let message = Message::Lobby(LobbyMessage::GameLobbyInfo {
+        let message = Message::GameLobbyInfo {
             lobby: self.shared.clone(),
-        });
+        };
         let _ = self.sender.send(message);
         Ok(())
     }
@@ -288,9 +280,9 @@ impl LobbyActor {
             .ok_or(LobbyError::PlayerInvalid(player_id))?;
 
         player.ready_to_start = can_start;
-        let message = Message::Lobby(LobbyMessage::GameLobbyInfo {
+        let message = Message::GameLobbyInfo {
             lobby: self.shared.clone(),
-        });
+        };
         let _ = self.sender.send(message);
         Ok(())
     }
@@ -305,9 +297,9 @@ impl LobbyActor {
         player.current_level = level;
         log::info!("Player {:#X} entered {level:?}", player_id);
 
-        let message = Message::Lobby(LobbyMessage::GameLobbyInfo {
+        let message = Message::GameLobbyInfo {
             lobby: self.shared.clone(),
-        });
+        };
         let _ = self.sender.send(message);
         Ok(())
     }
@@ -355,9 +347,9 @@ impl LobbyActor {
                         .unwrap_or(&0);
                 }
 
-                let message = Message::Lobby(LobbyMessage::GameLobbyInfo {
+                let message = Message::GameLobbyInfo {
                     lobby: self.shared.clone(),
-                });
+                };
                 let _ = self.sender.send(message);
             }
         }
@@ -370,9 +362,9 @@ impl LobbyActor {
         }
         self.shared.options = options;
 
-        let message = Message::Lobby(LobbyMessage::GameLobbyInfo {
+        let message = Message::GameLobbyInfo {
             lobby: self.shared.clone(),
-        });
+        };
         let _ = self.sender.send(message);
         Ok(())
     }

--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 
-use bfbb::game_interface::dolphin::DolphinInterface;
 use bfbb::game_interface::game_var::{GameVar, GameVarMut};
 use bfbb::game_interface::{InterfaceError, InterfaceProvider, InterfaceResult};
 use bfbb::game_state::{GameMode as BfBBGameMode, GameOstrich};
@@ -15,8 +14,8 @@ use crate::net::{NetCommand, NetCommandSender};
 
 use super::game_mode::GameMode;
 
-pub struct ClashGame {
-    provider: DolphinInterface,
+pub struct ClashGame<I> {
+    provider: I,
     lobby: NetworkedLobby,
     /// Not sure if this is the best approach, the idea is that it would be faster
     /// to store a local state of what we as a client have collected rather
@@ -25,12 +24,12 @@ pub struct ClashGame {
     player_id: PlayerId,
 }
 
-impl ClashGame {
-    pub fn new(player_id: PlayerId) -> Self {
+impl<I> ClashGame<I> {
+    pub fn new(provider: I, player_id: PlayerId) -> Self {
         Self {
-            provider: DolphinInterface::default(),
+            provider,
             // FIXME: would be better to be able to construct this object after receiving the initial lobby from the sever
-            // but that would complicate the logic thread logic a lot since the initial lobby is received as a regular LobbyMessage::GameLobbyInfo
+            // that's difficult because the client is given their id and their lobby in separate messages.
             lobby: NetworkedLobby::new(0),
             local_spat_state: HashSet::new(),
             player_id,
@@ -38,7 +37,7 @@ impl ClashGame {
     }
 }
 
-impl GameMode for ClashGame {
+impl<I: InterfaceProvider> GameMode for ClashGame<I> {
     /// Process state updates from the server and report back any actions of the local player
     fn update(&mut self, network_sender: &NetCommandSender) -> InterfaceResult<()> {
         self.provider.do_with_interface(|interface| {
@@ -155,18 +154,6 @@ impl GameMode for ClashGame {
                     .send((self.player_id, lobby.clone()))
                     .expect("GUI has crashed and so will we");
             }
-            LobbyMessage::GameLobbyInfo { lobby: new_lobby } => {
-                // This could fail if the user is restarting dolphin, but that will desync a lot of other things as well
-                // so it's fine to just wait for a future lobby update to correct the issue
-                let _ = self.provider.do_with_interface(|i| {
-                    i.spatula_count
-                        .set(new_lobby.game_state.spatulas.len() as u32)
-                });
-                self.lobby = new_lobby.clone();
-                gui_sender
-                    .send((self.player_id, new_lobby))
-                    .expect("GUI has crashed and so will we");
-            }
             // We're not yet doing partial updates
             LobbyMessage::PlayerOptions { options: _ } => todo!(),
             LobbyMessage::GameOptions { options: _ } => todo!(),
@@ -175,5 +162,178 @@ impl GameMode for ClashGame {
             LobbyMessage::GameCurrentLevel { level: _ } => todo!(),
             LobbyMessage::GameItemCollected { item: _ } => todo!(),
         }
+    }
+
+    fn update_lobby(&mut self, new_lobby: NetworkedLobby, gui_sender: &mut GuiSender) {
+        // This could fail if the user is restarting dolphin, but that will desync a lot of other things as well
+        // so it's fine to just wait for a future lobby update to correct the issue
+        let _ = self.provider.do_with_interface(|i| {
+            i.spatula_count
+                .set(new_lobby.game_state.spatulas.len() as u32)
+        });
+        self.lobby = new_lobby.clone();
+        gui_sender
+            .send((self.player_id, new_lobby))
+            .expect("GUI has crashed and so will we");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clash_lib::{
+        game_state::SpatulaState,
+        lobby::{GamePhase, NetworkedLobby},
+        net::{LobbyMessage, Message},
+        player::{NetworkedPlayer, PlayerOptions},
+    };
+
+    use bfbb::{
+        game_interface::{
+            mock::{mock_vars::MockBackend, MockInterface},
+            GameInterface, InterfaceProvider, InterfaceResult,
+        },
+        Level, Spatula,
+    };
+
+    use crate::{game::game_mode::GameMode, net::NetCommand};
+
+    use super::ClashGame;
+
+    fn setup_game(
+        provider_setup: impl FnOnce(&mut GameInterface<MockBackend>) -> InterfaceResult<()>,
+    ) -> ClashGame<MockInterface> {
+        // Run any required game-state setup code
+        let mut provider = MockInterface::default();
+        provider.do_with_interface(provider_setup).unwrap();
+
+        // Setup a default lobby state
+        let mut lobby = NetworkedLobby::new(0);
+        let mut player = NetworkedPlayer::new(PlayerOptions::default(), 0);
+        player.current_level = Some(Level::SpongebobHouse);
+        lobby.players.insert(0, player);
+        lobby.game_phase = GamePhase::Playing;
+
+        // Make new ClashGame and give it the default lobby
+        let (mut dummy_sender, _r) = std::sync::mpsc::channel();
+        let mut game = ClashGame::new(provider, 0);
+        game.update_lobby(lobby, &mut dummy_sender);
+        game
+    }
+
+    fn update_and_check(
+        game: &mut ClashGame<MockInterface>,
+        expected: impl IntoIterator<Item = LobbyMessage>,
+    ) {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(16);
+        game.update(&sender).unwrap();
+        for e in expected.into_iter() {
+            match receiver.try_recv() {
+                Ok(NetCommand::Send(Message::Lobby(m))) => assert_eq!(e, m),
+                Ok(m) => panic!("Incorrect Message. Got: {m:#?}\nExpected: {e:#?}"),
+                Err(_) => panic!("No message available. Expected message {e:#?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn spat_get_from_object() {
+        let mut game = setup_game(|interface| {
+            let task = &mut interface.tasks[Spatula::SpongebobsCloset];
+            task.state.as_mut().unwrap().value |= 4;
+            Ok(())
+        });
+        update_and_check(
+            &mut game,
+            Some(LobbyMessage::GameItemCollected {
+                item: Spatula::SpongebobsCloset.into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn spat_get_from_menu() {
+        let mut game = setup_game(|interface| {
+            let task = &mut interface.tasks[Spatula::OnTopOfThePineapple];
+            task.menu_count.value = 2;
+            Ok(())
+        });
+        update_and_check(
+            &mut game,
+            Some(LobbyMessage::GameItemCollected {
+                item: Spatula::OnTopOfThePineapple.into(),
+            }),
+        );
+    }
+
+    #[test]
+    fn no_collecting_when_loading() {
+        let mut game = setup_game(|interface| {
+            interface.is_loading.value = true;
+            let task = &mut interface.tasks[Spatula::OnTopOfThePineapple];
+            task.state.as_mut().unwrap().value |= 4;
+            task.menu_count.value = 2;
+            Ok(())
+        });
+        update_and_check(&mut game, None);
+    }
+
+    #[test]
+    fn no_collecting_when_on_menu() {
+        let mut game = setup_game(|interface| {
+            interface.scene_id.value = Level::MainMenu.into();
+            let task = &mut interface.tasks[Spatula::OnTopOfThePineapple];
+            task.state.as_mut().unwrap().value |= 4;
+            Ok(())
+        });
+        // Make sure no GameItemCollected message is emmitted.
+        update_and_check(
+            &mut game,
+            Some(LobbyMessage::GameCurrentLevel {
+                level: Some(Level::MainMenu),
+            }),
+        );
+
+        // Also ensure that we don't sync state while on the main menu
+        game.lobby.game_state.spatulas.insert(
+            Spatula::CowaBungee,
+            SpatulaState {
+                collection_vec: vec![1],
+            },
+        );
+        update_and_check(&mut game, None);
+        assert_eq!(game.provider.tasks[Spatula::CowaBungee].menu_count.value, 0);
+    }
+
+    #[test]
+    fn change_level() {
+        let mut game = setup_game(|interface| {
+            interface.scene_id.value = Level::JellyfishRock.into();
+            Ok(())
+        });
+        update_and_check(
+            &mut game,
+            Some(LobbyMessage::GameCurrentLevel {
+                level: Some(Level::JellyfishRock),
+            }),
+        )
+    }
+
+    #[test]
+    fn ng_plus_disables() {
+        let mut game = setup_game(|interface| {
+            interface.scene_id.value = Level::MainMenu.into();
+            Ok(())
+        });
+        game.lobby.options.ng_plus = true;
+
+        let (mut dummy_sender, _r) = std::sync::mpsc::channel();
+        game.message(LobbyMessage::GameBegin, &mut dummy_sender);
+        assert_eq!(game.provider.powers.initial_bubble_bowl.value, true);
+        assert_eq!(game.provider.powers.initial_cruise_bubble.value, true);
+
+        game.lobby.options.ng_plus = false;
+        game.message(LobbyMessage::GameBegin, &mut dummy_sender);
+        assert_eq!(game.provider.powers.initial_bubble_bowl.value, false);
+        assert_eq!(game.provider.powers.initial_cruise_bubble.value, false);
     }
 }

--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -328,12 +328,12 @@ mod tests {
 
         let (mut dummy_sender, _r) = std::sync::mpsc::channel();
         game.message(LobbyMessage::GameBegin, &mut dummy_sender);
-        assert_eq!(game.provider.powers.initial_bubble_bowl.value, true);
-        assert_eq!(game.provider.powers.initial_cruise_bubble.value, true);
+        assert!(game.provider.powers.initial_bubble_bowl.value);
+        assert!(game.provider.powers.initial_cruise_bubble.value);
 
         game.lobby.options.ng_plus = false;
         game.message(LobbyMessage::GameBegin, &mut dummy_sender);
-        assert_eq!(game.provider.powers.initial_bubble_bowl.value, false);
-        assert_eq!(game.provider.powers.initial_cruise_bubble.value, false);
+        assert!(!game.provider.powers.initial_bubble_bowl.value);
+        assert!(!game.provider.powers.initial_cruise_bubble.value);
     }
 }

--- a/crates/clash/src/game/game_mode.rs
+++ b/crates/clash/src/game/game_mode.rs
@@ -1,5 +1,5 @@
 use bfbb::game_interface::InterfaceResult;
-use clash_lib::net::LobbyMessage;
+use clash_lib::{lobby::NetworkedLobby, net::LobbyMessage};
 
 use crate::{gui::GuiSender, net::NetCommandSender};
 
@@ -10,4 +10,6 @@ pub trait GameMode {
     fn update(&mut self, network_sender: &NetCommandSender) -> InterfaceResult<()>;
 
     fn message(&mut self, message: LobbyMessage, gui_sender: &mut GuiSender);
+
+    fn update_lobby(&mut self, new_lobby: NetworkedLobby, gui_sender: &mut GuiSender);
 }

--- a/crates/clash/src/net.rs
+++ b/crates/clash/src/net.rs
@@ -16,6 +16,12 @@ pub enum NetCommand {
     Send(Message),
 }
 
+impl From<Message> for NetCommand {
+    fn from(msg: Message) -> Self {
+        Self::Send(msg)
+    }
+}
+
 #[tokio::main]
 pub async fn run(
     mut receiver: NetCommandReceiver,
@@ -85,6 +91,10 @@ async fn recv_task(
                 logic_sender.send(m).unwrap();
                 continue;
             }
+            m @ Message::GameLobbyInfo { lobby: _ } => {
+                logic_sender.send(m).unwrap();
+                continue;
+            }
             Message::Error { error } => {
                 log::error!("Error from server:\n{error}");
                 error_sender
@@ -102,9 +112,6 @@ async fn recv_task(
 
 fn process_action(action: LobbyMessage, logic_sender: &Sender<Message>) {
     match action {
-        m @ LobbyMessage::GameLobbyInfo { lobby: _ } => {
-            logic_sender.send(Message::Lobby(m)).unwrap();
-        }
         m @ LobbyMessage::GameBegin => {
             logic_sender.send(Message::Lobby(m)).unwrap();
         }


### PR DESCRIPTION
Eventually it would probably a good idea simply return game events from `update` and have the caller handle sending them over the network. We also need to break up the logic into smaller more testable functions but having the `self.provider.with_interface` call in `update` makes that tricky because of the mutable `self` borrow created there.