### PR TITLE
Drive futures in handshake error code

### DIFF
--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -65,23 +65,23 @@ impl ConnectingClient {
     }
 
     async fn handshake(mut self) -> Option<Client> {
-        let lobby_handle = self.try_handshake().await.map_or_else(
-            |error| {
-                let _ = self.conn_tx.write_frame(Message::Error { error });
-                None
-            },
-            Some,
-        )?;
+        let lobby_handle = match self.try_handshake().await {
+            Ok(it) => it,
+            Err(error) => {
+                let _ = self.conn_tx.write_frame(Message::Error { error }).await;
+                return None;
+            }
+        };
 
-        let lobby_recv = lobby_handle.join_lobby().await.map_or_else(
-            |error| {
+        let lobby_recv = match lobby_handle.join_lobby().await {
+            Ok(it) => it,
+            Err(error) => {
                 let _ = self.conn_tx.write_frame(Message::Error {
                     error: ProtocolError::Message(error.to_string()),
                 });
-                None
-            },
-            Some,
-        )?;
+                return None;
+            }
+        };
         Some(Client::from_connecting(self, lobby_handle, lobby_recv))
     }
 

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -76,9 +76,12 @@ impl ConnectingClient {
         let lobby_recv = match lobby_handle.join_lobby().await {
             Ok(it) => it,
             Err(error) => {
-                let _ = self.conn_tx.write_frame(Message::Error {
-                    error: ProtocolError::Message(error.to_string()),
-                });
+                let _ = self
+                    .conn_tx
+                    .write_frame(Message::Error {
+                        error: ProtocolError::Message(error.to_string()),
+                    })
+                    .await;
                 return None;
             }
         };


### PR DESCRIPTION
Closes #102 

This is a good example of how `let _ = ...` can be a hazardous footgun. We should probably think about banning the pattern entirely, at least in async code. There are some existing lints we could use. Issue is that this is what we want to right now with the awaited Result. There's not much left to do if we fail to tell the client about an error other than to move on. We could log it but that seems fairly unnecessary. It shouldn't matter much to the server whether this succeeds or fails, the handshake has already failed and the client will be dropped regardless.