### PR TITLE
Setup `tracing` and`tracing-subscriber`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,13 +324,13 @@ dependencies = [
  "bfbb",
  "clash_lib",
  "eframe",
- "env_logger",
  "image",
  "itertools",
- "log",
  "spin_sleep",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "version_gen",
  "winres",
 ]
@@ -342,11 +342,11 @@ dependencies = [
  "anyhow",
  "bfbb",
  "clash_lib",
- "env_logger",
- "log",
  "rand",
  "thiserror",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "version_gen",
 ]
 
@@ -358,10 +358,10 @@ dependencies = [
  "bincode",
  "bytes",
  "epaint",
- "log",
  "serde",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1561,6 +1561,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1689,6 +1699,12 @@ checksum = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 dependencies = [
  "shared_library",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -2038,6 +2054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,6 +2250,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "threadpool"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,7 +2364,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2340,6 +2386,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2379,6 +2451,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ edition = "2021"
 anyhow = "1"
 bfbb = "0.3.0-beta.1"
 clash_lib = { path = "crates/clash-lib" }
-env_logger = "0.9"
-log = "0.4"
 thiserror = "1"
 tokio = { version = "1", features = [
     "rt",
@@ -26,6 +24,8 @@ tokio = { version = "1", features = [
     "sync",
     "time",
 ] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 version_gen = { path = "crates/version-gen" }
 
 # Remove unneeded debug info from linux release binaries

--- a/crates/clash-lib/Cargo.toml
+++ b/crates/clash-lib/Cargo.toml
@@ -6,9 +6,9 @@ publish = false
 
 [dependencies]
 bfbb = { workspace = true, features = ["serde"] }
-log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 bincode = "1"
 bytes = "1"

--- a/crates/clash-lib/src/lib.rs
+++ b/crates/clash-lib/src/lib.rs
@@ -1,3 +1,10 @@
+use std::{
+    borrow::Borrow,
+    fmt::{Debug, Display},
+};
+
+use serde::{Deserialize, Serialize};
+
 pub mod game_state;
 pub mod lobby;
 pub mod net;
@@ -5,7 +12,53 @@ pub mod player;
 
 pub const MAX_PLAYERS: usize = 6;
 
-// NOTE: We can considering using the newtype pattern here to avoid the possiblity of mixing up these id types,
-//       but it adds a lot of boilerplate and I'm not sure that it's actually worth it at this point.
-pub type PlayerId = u32;
-pub type LobbyId = u32;
+// Setup Newtype pattern for IDs
+macro_rules! decl_id {
+    ($name:ident) => {
+        #[derive(Copy, Clone, PartialEq, Eq, Deserialize, Serialize, Hash)]
+        pub struct $name(pub u32);
+
+        impl Debug for $name {
+            #[inline]
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                <Self as Display>::fmt(self, f)
+            }
+        }
+        impl Display for $name {
+            #[inline]
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                // Always diplay IDs in hex
+                write!(f, "{:#X}", self.0)
+            }
+        }
+
+        impl From<u32> for $name {
+            #[inline]
+            fn from(v: u32) -> Self {
+                Self(v)
+            }
+        }
+        impl From<$name> for u32 {
+            #[inline]
+            fn from(v: $name) -> Self {
+                v.0
+            }
+        }
+
+        impl Borrow<u32> for $name {
+            #[inline]
+            fn borrow(&self) -> &u32 {
+                &self.0
+            }
+        }
+        impl PartialEq<u32> for $name {
+            #[inline]
+            fn eq(&self, other: &u32) -> bool {
+                self.0 == *other
+            }
+        }
+    };
+}
+
+decl_id!(PlayerId);
+decl_id!(LobbyId);

--- a/crates/clash-lib/src/lobby.rs
+++ b/crates/clash-lib/src/lobby.rs
@@ -42,10 +42,10 @@ pub struct NetworkedLobby {
 }
 
 impl NetworkedLobby {
-    pub fn new(lobby_id: u32) -> Self {
+    pub fn new(lobby_id: impl Into<LobbyId>) -> Self {
         Self {
             game_state: GameState::default(),
-            lobby_id,
+            lobby_id: lobby_id.into(),
             options: LobbyOptions::default(),
             players: HashMap::new(),
             game_phase: GamePhase::Setup,
@@ -81,7 +81,7 @@ mod tests {
         let mut lobby = NetworkedLobby::new(0);
         let player_0 = lobby
             .players
-            .entry(0)
+            .entry(0.into())
             .or_insert_with(|| NetworkedPlayer::new(PlayerOptions::default(), 0));
         player_0.ready_to_start = true;
 
@@ -89,7 +89,7 @@ mod tests {
 
         lobby
             .players
-            .entry(1)
+            .entry(1.into())
             .or_insert_with(|| NetworkedPlayer::new(PlayerOptions::default(), 1));
         assert!(!lobby.can_start());
 
@@ -102,7 +102,7 @@ mod tests {
         let mut lobby = NetworkedLobby::new(0);
         let player_0 = lobby
             .players
-            .entry(0)
+            .entry(0.into())
             .or_insert_with(|| NetworkedPlayer::new(PlayerOptions::default(), 0));
 
         lobby.game_phase = GamePhase::Playing;
@@ -110,7 +110,7 @@ mod tests {
         lobby.game_state.spatulas.insert(
             Spatula::SpongebobsCloset,
             SpatulaState {
-                collection_vec: vec![0],
+                collection_vec: vec![0.into()],
             },
         );
 

--- a/crates/clash-lib/src/net/error.rs
+++ b/crates/clash-lib/src/net/error.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 #[derive(Error, Clone, Debug, Serialize, Deserialize)]
 pub enum ProtocolError {
-    #[error("Invalid Lobby ID {0:#X}")]
+    #[error("Invalid Lobby ID {0}")]
     InvalidLobbyId(LobbyId),
     #[error("Invalid Message")]
     InvalidMessage,

--- a/crates/clash-lib/src/net/message.rs
+++ b/crates/clash-lib/src/net/message.rs
@@ -1,5 +1,6 @@
 use crate::lobby::{LobbyOptions, NetworkedLobby};
 use crate::player::PlayerOptions;
+use crate::{LobbyId, PlayerId};
 use bfbb::{Level, Spatula};
 use serde::{Deserialize, Serialize};
 
@@ -10,9 +11,9 @@ use super::ProtocolError;
 pub enum Message {
     Error { error: ProtocolError },
     Version { version: String },
-    ConnectionAccept { player_id: u32 },
+    ConnectionAccept { player_id: PlayerId },
     GameHost,
-    GameJoin { lobby_id: u32 },
+    GameJoin { lobby_id: LobbyId },
     Lobby(LobbyMessage),
     GameLobbyInfo { lobby: NetworkedLobby },
 }

--- a/crates/clash-server/Cargo.toml
+++ b/crates/clash-server/Cargo.toml
@@ -12,8 +12,8 @@ bfbb.workspace = true
 clash_lib.workspace = true
 tokio.workspace = true
 thiserror.workspace = true
-env_logger.workspace = true
-log.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 rand = "0.8"
 

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -108,7 +108,7 @@ impl ConnectingClient {
                 player_id: self.player_id,
             })
             .await?;
-        tracing::info!("New connection for player id {:#X} opened", self.player_id);
+        tracing::info!("New connection for player id {} opened", self.player_id);
 
         let lobby_handle = match self.conn_rx.read_frame().await? {
             Some(Message::GameHost) => {
@@ -173,7 +173,7 @@ impl Client {
                 Ok(Some(Message::Lobby(x))) => x,
                 Ok(Some(m)) => {
                     tracing::error!(
-                        "Invalid message received from Player {:#X}: \n{m:?}",
+                        "Invalid message received from Player {}: \n{m:?}",
                         self.player_id
                     );
                     let _ = self
@@ -189,7 +189,7 @@ impl Client {
                 }
                 Err(e) => {
                     tracing::error!(
-                        "Error reading message from player id {:#X}. Closing connection\n{e:?}",
+                        "Error reading message from player id {}. Closing connection\n{e:?}",
                         self.player_id
                     );
                     break;
@@ -197,13 +197,13 @@ impl Client {
             };
 
             tracing::debug!(
-                "Received message from player id {:#X} \nMessage: {incoming:#X?}",
+                "Received message from player id {} \nMessage: {incoming:?}",
                 self.player_id,
             );
             match self.process(incoming).await {
                 Ok(()) => (),
                 Err(e) => {
-                    tracing::error!("Player {:#X} encountered error {e:?}", self.player_id);
+                    tracing::error!("Player {} encountered error {e:?}", self.player_id);
                     let _ = self
                         .local_tx
                         .send(Message::Error {
@@ -213,7 +213,7 @@ impl Client {
                 }
             }
         }
-        tracing::info!("Player {:#X} disconnected", self.player_id);
+        tracing::info!("Player {} disconnected", self.player_id);
     }
 
     async fn process(&mut self, msg: LobbyMessage) -> Result<(), LobbyError> {

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -108,7 +108,7 @@ impl ConnectingClient {
                 player_id: self.player_id,
             })
             .await?;
-        log::info!("New connection for player id {:#X} opened", self.player_id);
+        tracing::info!("New connection for player id {:#X} opened", self.player_id);
 
         let lobby_handle = match self.conn_rx.read_frame().await? {
             Some(Message::GameHost) => {
@@ -172,7 +172,7 @@ impl Client {
             let incoming = match self.conn_rx.read_frame().await {
                 Ok(Some(Message::Lobby(x))) => x,
                 Ok(Some(m)) => {
-                    log::error!(
+                    tracing::error!(
                         "Invalid message received from Player {:#X}: \n{m:?}",
                         self.player_id
                     );
@@ -188,7 +188,7 @@ impl Client {
                     break;
                 }
                 Err(e) => {
-                    log::error!(
+                    tracing::error!(
                         "Error reading message from player id {:#X}. Closing connection\n{e:?}",
                         self.player_id
                     );
@@ -196,14 +196,14 @@ impl Client {
                 }
             };
 
-            log::debug!(
+            tracing::debug!(
                 "Received message from player id {:#X} \nMessage: {incoming:#X?}",
                 self.player_id,
             );
             match self.process(incoming).await {
                 Ok(()) => (),
                 Err(e) => {
-                    log::error!("Player {:#X} encountered error {e:?}", self.player_id);
+                    tracing::error!("Player {:#X} encountered error {e:?}", self.player_id);
                     let _ = self
                         .local_tx
                         .send(Message::Error {
@@ -213,7 +213,7 @@ impl Client {
                 }
             }
         }
-        log::info!("Player {:#X} disconnected", self.player_id);
+        tracing::info!("Player {:#X} disconnected", self.player_id);
     }
 
     async fn process(&mut self, msg: LobbyMessage) -> Result<(), LobbyError> {

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -7,6 +7,7 @@ use tokio::net::TcpStream;
 use tokio::select;
 use tokio::sync::{broadcast, mpsc};
 use tokio::task::JoinHandle;
+use tracing::instrument;
 
 use crate::lobby::lobby_handle::LobbyHandle;
 use crate::lobby::LobbyError;
@@ -19,24 +20,6 @@ pub async fn handle_new_connection(state: ServerState, socket: TcpStream) {
         None => return,
     };
     client.run().await;
-}
-
-async fn send_task(
-    mut conn_tx: ConnectionTx,
-    mut lobby_rx: tokio::sync::broadcast::Receiver<Message>,
-    mut local_rx: tokio::sync::mpsc::Receiver<Message>,
-) {
-    loop {
-        let m = select! {
-            Ok(m) = lobby_rx.recv() => m,
-            Some(m) = local_rx.recv() => m,
-            else => return,
-        };
-
-        if conn_tx.write_frame(m).await.is_err() {
-            return;
-        }
-    }
 }
 
 /// Represents a client who just connected and still needs to tell the server what they want to do.
@@ -135,6 +118,24 @@ impl ConnectingClient {
     }
 }
 
+async fn send_task(
+    mut conn_tx: ConnectionTx,
+    mut lobby_rx: tokio::sync::broadcast::Receiver<Message>,
+    mut local_rx: tokio::sync::mpsc::Receiver<Message>,
+) {
+    loop {
+        let m = select! {
+            Ok(m) = lobby_rx.recv() => m,
+            Some(m) = local_rx.recv() => m,
+            else => return,
+        };
+
+        if conn_tx.write_frame(m).await.is_err() {
+            return;
+        }
+    }
+}
+
 /// Used to represent a client who is in a lobby.
 struct Client {
     state: ServerState,
@@ -167,15 +168,13 @@ impl Client {
 
     /// Takes ownership of self to guarantee that client will be dropped when it's
     /// message loop ends
+    #[instrument(skip_all, fields(player_id = %self.player_id))]
     pub async fn run(mut self) {
         loop {
             let incoming = match self.conn_rx.read_frame().await {
                 Ok(Some(Message::Lobby(x))) => x,
                 Ok(Some(m)) => {
-                    tracing::error!(
-                        "Invalid message received from Player {}: \n{m:?}",
-                        self.player_id
-                    );
+                    tracing::error!("Invalid message received: {m:?}");
                     let _ = self
                         .local_tx
                         .send(Message::Error {
@@ -188,22 +187,16 @@ impl Client {
                     break;
                 }
                 Err(e) => {
-                    tracing::error!(
-                        "Error reading message from player id {}. Closing connection\n{e:?}",
-                        self.player_id
-                    );
+                    tracing::error!("Error reading message, Closing connection\n{e:?}",);
                     break;
                 }
             };
 
-            tracing::debug!(
-                "Received message from player id {} \nMessage: {incoming:?}",
-                self.player_id,
-            );
+            tracing::debug!("Received message: {incoming:#?}");
             match self.process(incoming).await {
                 Ok(()) => (),
                 Err(e) => {
-                    tracing::error!("Player {} encountered error {e:?}", self.player_id);
+                    tracing::error!("Encountered error processing message: {e:?}");
                     let _ = self
                         .local_tx
                         .send(Message::Error {
@@ -213,36 +206,28 @@ impl Client {
                 }
             }
         }
-        tracing::info!("Player {} disconnected", self.player_id);
+        tracing::info!("Player disconnected");
     }
 
     async fn process(&mut self, msg: LobbyMessage) -> Result<(), LobbyError> {
         match msg {
             LobbyMessage::PlayerOptions { options } => {
-                self.lobby_handle.set_player_options(options).await?;
+                self.lobby_handle.set_player_options(options).await
             }
-            LobbyMessage::PlayerCanStart(val) => {
-                self.lobby_handle.set_player_can_start(val).await?;
-            }
-            LobbyMessage::ResetLobby => {
-                self.lobby_handle.reset_lobby().await?;
-            }
+            LobbyMessage::PlayerCanStart(val) => self.lobby_handle.set_player_can_start(val).await,
+            LobbyMessage::ResetLobby => self.lobby_handle.reset_lobby().await,
             LobbyMessage::GameOptions { options } => {
-                self.lobby_handle.set_game_options(options).await?;
+                self.lobby_handle.set_game_options(options).await
             }
-            LobbyMessage::GameBegin => {
-                self.lobby_handle.start_game().await?;
-            }
+            LobbyMessage::GameBegin => self.lobby_handle.start_game().await,
             LobbyMessage::GameCurrentLevel { level } => {
-                self.lobby_handle.set_player_level(level).await?;
+                self.lobby_handle.set_player_level(level).await
             }
             LobbyMessage::GameItemCollected { item } => {
-                self.lobby_handle.player_collected_item(item).await?;
+                self.lobby_handle.player_collected_item(item).await
             }
             LobbyMessage::GameEnd => todo!(),
         }
-
-        Ok(())
     }
 }
 

--- a/crates/clash-server/src/lobby/lobby_actor.rs
+++ b/crates/clash-server/src/lobby/lobby_actor.rs
@@ -132,7 +132,7 @@ impl LobbyActor {
         // Remove this lobby from the server
         let state = &mut *self.state.lock().unwrap();
         state.lobbies.remove(&self.shared.lobby_id);
-        tracing::info!("Closing lobby {:#X}", self.shared.lobby_id);
+        tracing::info!("Closing lobby {}", self.shared.lobby_id);
     }
 
     fn send_lobby(&mut self) {
@@ -163,7 +163,7 @@ impl LobbyActor {
 
         if !self.shared.can_start() {
             tracing::warn!(
-                "Lobby {:#X} attempted to start when some players aren't able to start.",
+                "Lobby {} attempted to start when some players aren't able to start.",
                 self.shared.lobby_id
             );
             // Maybe this should be an error, I'm not sure
@@ -179,7 +179,7 @@ impl LobbyActor {
             .is_err()
         {
             tracing::warn!(
-                "Lobby {:#X} started with no players in lobby.",
+                "Lobby {} started with no players in lobby.",
                 self.shared.lobby_id
             )
         }
@@ -286,7 +286,7 @@ impl LobbyActor {
             .ok_or(LobbyError::PlayerInvalid(player_id))?;
 
         player.current_level = level;
-        tracing::info!("Player {:#X} entered {level:?}", player_id);
+        tracing::info!("Player {} entered {level:?}", player_id);
 
         self.send_lobby();
         Ok(())
@@ -307,7 +307,7 @@ impl LobbyActor {
                 // before receiving the lobby update that exhausted it. We should just ignore this case
                 if state.collection_vec.len() == self.shared.options.tier_count.into() {
                     tracing::info!(
-                        "Player {player_id:#X} tried to collect exhausted spatula {spat:?}.",
+                        "Player {player_id} tried to collect exhausted spatula {spat:?}.",
                     );
                     return Ok(());
                 }
@@ -318,7 +318,7 @@ impl LobbyActor {
 
                 state.collection_vec.push(player_id);
                 tracing::info!(
-                    "Player {player_id:#X} collected {spat:?} with tier {:?}",
+                    "Player {player_id} collected {spat:?} with tier {:?}",
                     state.collection_vec.len()
                 );
 
@@ -330,7 +330,7 @@ impl LobbyActor {
                         .is_err()
                     {
                         tracing::warn!(
-                            "Lobby {:#X} finished with no players in lobby.",
+                            "Lobby {} finished with no players in lobby.",
                             self.shared.lobby_id
                         )
                     }
@@ -375,20 +375,20 @@ mod test {
 
     fn setup() -> LobbyActor {
         let (_, rx) = mpsc::channel(2);
-        LobbyActor::new(Default::default(), rx, 0)
+        LobbyActor::new(Default::default(), rx, 0.into())
     }
 
     #[test]
     fn reset_lobby() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
-        lobby.start_game(0).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
+        lobby.start_game(0.into()).unwrap();
 
-        let Err(LobbyError::NeedsHost) = lobby.reset_lobby(1) else {
+        let Err(LobbyError::NeedsHost) = lobby.reset_lobby(1.into()) else {
             panic!("Only the host should be able to reset the lobby");
         };
-        let Ok(()) = lobby.reset_lobby(0) else {
+        let Ok(()) = lobby.reset_lobby(0.into()) else {
             panic!("Host was unable to reset lobby");
         };
     }
@@ -396,20 +396,20 @@ mod test {
     #[test]
     fn start_game() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
 
         // Only the host can start a game
-        assert_eq!(lobby.start_game(1), Err(LobbyError::NeedsHost));
+        assert_eq!(lobby.start_game(1.into()), Err(LobbyError::NeedsHost));
 
         // Starting while not all players are on the main menu silently fails (at least for now)
-        lobby.set_player_can_start(0, true).unwrap();
-        assert!(lobby.start_game(0).is_ok());
+        lobby.set_player_can_start(0.into(), true).unwrap();
+        assert!(lobby.start_game(0.into()).is_ok());
         assert_eq!(lobby.shared.game_phase, GamePhase::Setup);
 
         // Now we can start
-        lobby.set_player_can_start(1, true).unwrap();
-        assert!(lobby.start_game(0).is_ok());
+        lobby.set_player_can_start(1.into(), true).unwrap();
+        assert!(lobby.start_game(0.into()).is_ok());
         assert_eq!(lobby.shared.game_phase, GamePhase::Playing);
     }
 
@@ -418,41 +418,44 @@ mod test {
         let mut lobby = setup();
 
         for i in 0..clash_lib::MAX_PLAYERS as u32 {
-            assert!(lobby.add_player(i).is_ok());
+            assert!(lobby.add_player(i.into()).is_ok());
             assert!(lobby.shared.players.contains_key(&i));
         }
-        assert_eq!(lobby.shared.host_id, Some(0));
+        assert_eq!(lobby.shared.host_id, Some(0.into()));
 
         // Adding a seventh player will fail
-        assert!(matches!(lobby.add_player(6), Err(LobbyError::LobbyFull)));
+        assert!(matches!(
+            lobby.add_player(6.into()),
+            Err(LobbyError::LobbyFull)
+        ));
     }
 
     #[test]
     fn remove_player() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
 
         // Removing the host will assign a new one
-        lobby.rem_player(0);
+        lobby.rem_player(0.into());
         assert!(!lobby.shared.players.contains_key(&0));
-        assert_eq!(lobby.shared.host_id, Some(1));
+        assert_eq!(lobby.shared.host_id, Some(1.into()));
 
         // Removing the last player will close the lobby
-        lobby.rem_player(1);
+        lobby.rem_player(1.into());
         assert!(lobby.shared.players.is_empty());
     }
 
     #[test]
     fn set_player_options() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
 
         // Can't set options for a non-existant player
         assert_eq!(
-            lobby.set_player_options(1337, Default::default()),
-            Err(LobbyError::PlayerInvalid(1337))
+            lobby.set_player_options(1337.into(), Default::default()),
+            Err(LobbyError::PlayerInvalid(1337.into()))
         );
 
         let square = PlayerOptions {
@@ -463,8 +466,8 @@ mod test {
             name: "Rectangle".to_owned(),
             ..Default::default()
         };
-        assert!(lobby.set_player_options(0, square).is_ok());
-        assert!(lobby.set_player_options(1, rectangle).is_ok());
+        assert!(lobby.set_player_options(0.into(), square).is_ok());
+        assert!(lobby.set_player_options(1.into(), rectangle).is_ok());
 
         assert_eq!(
             lobby.shared.players.get(&0).unwrap().options.name,
@@ -479,17 +482,21 @@ mod test {
     #[test]
     fn set_player_level() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
 
         // Can't set level for a non-existant player
         assert_eq!(
-            lobby.set_player_level(1337, Default::default()),
-            Err(LobbyError::PlayerInvalid(1337))
+            lobby.set_player_level(1337.into(), Default::default()),
+            Err(LobbyError::PlayerInvalid(1337.into()))
         );
 
-        assert!(lobby.set_player_level(0, Some(Level::BikiniBottom)).is_ok());
-        assert!(lobby.set_player_level(1, Some(Level::ShadyShoals)).is_ok());
+        assert!(lobby
+            .set_player_level(0.into(), Some(Level::BikiniBottom))
+            .is_ok());
+        assert!(lobby
+            .set_player_level(1.into(), Some(Level::ShadyShoals))
+            .is_ok());
 
         assert_eq!(
             lobby.shared.players.get(&0).unwrap().current_level,
@@ -504,11 +511,11 @@ mod test {
     #[test]
     fn collect_small_shall_rule() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
+        lobby.add_player(0.into()).unwrap();
 
         // Collecting Small Shall Rule finishes the match
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::TheSmallShallRuleOrNot))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::TheSmallShallRuleOrNot))
             .is_ok());
         assert_eq!(lobby.shared.game_phase, GamePhase::Finished);
     }
@@ -516,17 +523,17 @@ mod test {
     #[test]
     fn player_collected_item_state() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
 
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::SpongebobsCloset))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::SpongebobsCloset))
             .is_ok());
         assert!(lobby
-            .player_collected_item(1, Item::Spatula(Spatula::SpongebobsCloset))
+            .player_collected_item(1.into(), Item::Spatula(Spatula::SpongebobsCloset))
             .is_ok());
         assert!(lobby
-            .player_collected_item(1, Item::Spatula(Spatula::OnTopOfThePineapple))
+            .player_collected_item(1.into(), Item::Spatula(Spatula::OnTopOfThePineapple))
             .is_ok());
 
         // Only two unique spatulas were collected
@@ -546,43 +553,43 @@ mod test {
     #[test]
     fn player_collected_item_score() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
-        lobby.add_player(2).unwrap();
-        lobby.add_player(3).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
+        lobby.add_player(2.into()).unwrap();
+        lobby.add_player(3.into()).unwrap();
 
         // Non-existant player can't collect an item
         assert_eq!(
-            lobby.player_collected_item(1337, Item::Spatula(Spatula::CowaBungee)),
-            Err(LobbyError::PlayerInvalid(1337))
+            lobby.player_collected_item(1337.into(), Item::Spatula(Spatula::CowaBungee)),
+            Err(LobbyError::PlayerInvalid(1337.into()))
         );
 
         // CBL Spats are worth 0 points
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::KahRahTae))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::KahRahTae))
             .is_ok());
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::TheSmallShallRuleOrNot))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::TheSmallShallRuleOrNot))
             .is_ok());
         assert_eq!(lobby.shared.players.get(&0).unwrap().score, 0);
 
         // Collecting a spatula first grants highest score
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::SpongebobsCloset))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::SpongebobsCloset))
             .is_ok());
         assert!(lobby
-            .player_collected_item(1, Item::Spatula(Spatula::OnTopOfThePineapple))
+            .player_collected_item(1.into(), Item::Spatula(Spatula::OnTopOfThePineapple))
             .is_ok());
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::CowaBungee))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::CowaBungee))
             .is_ok());
 
         // A new player collecting a spatula again gives fewer points
         assert!(lobby
-            .player_collected_item(1, Item::Spatula(Spatula::SpongebobsCloset))
+            .player_collected_item(1.into(), Item::Spatula(Spatula::SpongebobsCloset))
             .is_ok());
         assert!(lobby
-            .player_collected_item(2, Item::Spatula(Spatula::SpongebobsCloset))
+            .player_collected_item(2.into(), Item::Spatula(Spatula::SpongebobsCloset))
             .is_ok());
 
         let points = &lobby.shared.options.spat_scores;
@@ -598,20 +605,20 @@ mod test {
     #[test]
     fn player_collected_item_max() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
-        lobby.add_player(1).unwrap();
-        lobby.add_player(2).unwrap();
-        lobby.add_player(3).unwrap();
+        lobby.add_player(0.into()).unwrap();
+        lobby.add_player(1.into()).unwrap();
+        lobby.add_player(2.into()).unwrap();
+        lobby.add_player(3.into()).unwrap();
 
         for i in 0..=2 {
             assert!(lobby
-                .player_collected_item(i, Item::Spatula(Spatula::SpongebobsCloset))
+                .player_collected_item(i.into(), Item::Spatula(Spatula::SpongebobsCloset))
                 .is_ok());
         }
 
         // A new player collecting an exhausted spatula will simply be ignored
         assert_eq!(
-            lobby.player_collected_item(3, Item::Spatula(Spatula::SpongebobsCloset)),
+            lobby.player_collected_item(3.into(), Item::Spatula(Spatula::SpongebobsCloset)),
             Ok(())
         );
         let closet_state = lobby
@@ -620,15 +627,15 @@ mod test {
             .spatulas
             .get(&Spatula::SpongebobsCloset)
             .unwrap();
-        assert!(!closet_state.collection_vec.contains(&3),);
+        assert!(!closet_state.collection_vec.contains(&3.into()),);
         assert_eq!(lobby.shared.players.get(&3).unwrap().score, 0);
 
         lobby.shared.options.tier_count = 1;
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::OnTopOfThePineapple))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::OnTopOfThePineapple))
             .is_ok());
         assert_eq!(
-            lobby.player_collected_item(1, Item::Spatula(Spatula::OnTopOfThePineapple)),
+            lobby.player_collected_item(1.into(), Item::Spatula(Spatula::OnTopOfThePineapple)),
             Ok(())
         );
     }
@@ -636,15 +643,15 @@ mod test {
     #[test]
     fn player_collected_item_twice() {
         let mut lobby = setup();
-        lobby.add_player(0).unwrap();
+        lobby.add_player(0.into()).unwrap();
 
         // Same player can't collect an item that they already collected once
         assert!(lobby
-            .player_collected_item(0, Item::Spatula(Spatula::CowaBungee))
+            .player_collected_item(0.into(), Item::Spatula(Spatula::CowaBungee))
             .is_ok());
         assert_eq!(
-            lobby.player_collected_item(0, Item::Spatula(Spatula::CowaBungee)),
-            Err(LobbyError::InvalidAction(0))
+            lobby.player_collected_item(0.into(), Item::Spatula(Spatula::CowaBungee)),
+            Err(LobbyError::InvalidAction(0.into()))
         );
         assert_eq!(
             lobby
@@ -666,20 +673,20 @@ mod test {
     async fn lobby_dies() {
         let get_lobby = || {
             let (tx, rx) = mpsc::channel(2);
-            let mut actor = LobbyActor::new(Default::default(), rx, 0);
+            let mut actor = LobbyActor::new(Default::default(), rx, 0.into());
             let handle = LobbyHandleProvider {
                 sender: tx,
-                lobby_id: 0,
+                lobby_id: 0.into(),
             }
             .get_handle(0);
-            actor.add_player(0).unwrap();
+            actor.add_player(0.into()).unwrap();
             (actor, handle)
         };
 
         // The lobby will run for as long as handles remain
         {
             let (actor, handle) = get_lobby();
-            timeout(Duration::from_secs(1), actor.run())
+            timeout(Duration::from_millis(50), actor.run())
                 .await
                 .expect_err("Lobby closed with handles still remaining");
             // Explicitly drop handle to ensure it's not dropped early
@@ -691,7 +698,7 @@ mod test {
             let (actor, handle) = get_lobby();
 
             drop(handle);
-            timeout(Duration::from_secs(1), actor.run())
+            timeout(Duration::from_millis(50), actor.run())
                 .await
                 .expect("Lobby failed to close");
         }
@@ -700,8 +707,8 @@ mod test {
         {
             let (mut actor, handle) = get_lobby();
 
-            actor.rem_player(0);
-            timeout(Duration::from_secs(1), actor.run())
+            actor.rem_player(0.into());
+            timeout(Duration::from_millis(50), actor.run())
                 .await
                 .expect("Lobby failed to close");
             // Explicitly drop handle to ensure it's not dropped early

--- a/crates/clash-server/src/lobby/lobby_actor.rs
+++ b/crates/clash-server/src/lobby/lobby_actor.rs
@@ -700,11 +700,7 @@ mod test {
         let get_lobby = || {
             let (tx, rx) = mpsc::channel(2);
             let mut actor = LobbyActor::new(Default::default(), rx, 0.into());
-            let handle = LobbyHandleProvider {
-                sender: tx,
-                lobby_id: 0.into(),
-            }
-            .get_handle(0);
+            let handle = LobbyHandleProvider { sender: tx }.get_handle(0);
             actor.add_player(0.into()).unwrap();
             (actor, handle)
         };

--- a/crates/clash-server/src/lobby/lobby_actor.rs
+++ b/crates/clash-server/src/lobby/lobby_actor.rs
@@ -132,7 +132,7 @@ impl LobbyActor {
         // Remove this lobby from the server
         let state = &mut *self.state.lock().unwrap();
         state.lobbies.remove(&self.shared.lobby_id);
-        log::info!("Closing lobby {:#X}", self.shared.lobby_id);
+        tracing::info!("Closing lobby {:#X}", self.shared.lobby_id);
     }
 
     fn send_lobby(&mut self) {
@@ -162,7 +162,7 @@ impl LobbyActor {
         }
 
         if !self.shared.can_start() {
-            log::warn!(
+            tracing::warn!(
                 "Lobby {:#X} attempted to start when some players aren't able to start.",
                 self.shared.lobby_id
             );
@@ -178,7 +178,7 @@ impl LobbyActor {
             .send(Message::Lobby(LobbyMessage::GameBegin))
             .is_err()
         {
-            log::warn!(
+            tracing::warn!(
                 "Lobby {:#X} started with no players in lobby.",
                 self.shared.lobby_id
             )
@@ -223,7 +223,7 @@ impl LobbyActor {
     /// Removes a player from the lobby. If the host is removed, a new host is assigned randomly.
     fn rem_player(&mut self, player_id: PlayerId) {
         if self.shared.players.remove(&player_id).is_none() {
-            log::warn!(
+            tracing::warn!(
                 "Attempted to remove player {:#} from lobby {:#} who isn't in it",
                 player_id,
                 self.shared.lobby_id
@@ -286,7 +286,7 @@ impl LobbyActor {
             .ok_or(LobbyError::PlayerInvalid(player_id))?;
 
         player.current_level = level;
-        log::info!("Player {:#X} entered {level:?}", player_id);
+        tracing::info!("Player {:#X} entered {level:?}", player_id);
 
         self.send_lobby();
         Ok(())
@@ -306,7 +306,7 @@ impl LobbyActor {
                 // This can happen in rare situations where the player colllected an exhausted spatula
                 // before receiving the lobby update that exhausted it. We should just ignore this case
                 if state.collection_vec.len() == self.shared.options.tier_count.into() {
-                    log::info!(
+                    tracing::info!(
                         "Player {player_id:#X} tried to collect exhausted spatula {spat:?}.",
                     );
                     return Ok(());
@@ -317,7 +317,7 @@ impl LobbyActor {
                 }
 
                 state.collection_vec.push(player_id);
-                log::info!(
+                tracing::info!(
                     "Player {player_id:#X} collected {spat:?} with tier {:?}",
                     state.collection_vec.len()
                 );
@@ -329,7 +329,7 @@ impl LobbyActor {
                         .send(Message::Lobby(LobbyMessage::GameEnd))
                         .is_err()
                     {
-                        log::warn!(
+                        tracing::warn!(
                             "Lobby {:#X} finished with no players in lobby.",
                             self.shared.lobby_id
                         )

--- a/crates/clash-server/src/lobby/lobby_handle.rs
+++ b/crates/clash-server/src/lobby/lobby_handle.rs
@@ -3,7 +3,7 @@ use clash_lib::{
     lobby::LobbyOptions,
     net::{Item, Message},
     player::PlayerOptions,
-    LobbyId, PlayerId,
+    PlayerId,
 };
 use tokio::sync::{broadcast, mpsc, oneshot};
 
@@ -13,14 +13,12 @@ use super::LobbyError;
 #[derive(Debug)]
 pub struct LobbyHandleProvider {
     pub(super) sender: mpsc::Sender<LobbyAction>,
-    pub(super) lobby_id: LobbyId,
 }
 
 impl LobbyHandleProvider {
     pub fn get_handle(&self, player_id: impl Into<PlayerId>) -> LobbyHandle {
         LobbyHandle {
             sender: self.sender.clone(),
-            lobby_id: self.lobby_id,
             player_id: player_id.into(),
         }
     }
@@ -29,7 +27,6 @@ impl LobbyHandleProvider {
 #[derive(Clone, Debug)]
 pub struct LobbyHandle {
     sender: mpsc::Sender<LobbyAction>,
-    lobby_id: LobbyId,
     player_id: PlayerId,
 }
 
@@ -151,7 +148,6 @@ mod test {
         let (tx, rx) = mpsc::channel(2);
         let handle = LobbyHandle {
             sender: tx,
-            lobby_id: 0.into(),
             player_id: 123.into(),
         };
         (rx, handle)
@@ -161,7 +157,6 @@ mod test {
     fn lobby_provider_provides_new_handle() {
         let handle_provider = LobbyHandleProvider {
             sender: mpsc::channel(2).0,
-            lobby_id: 0.into(),
         };
 
         let handle = handle_provider.get_handle(123);

--- a/crates/clash-server/src/lobby/lobby_handle.rs
+++ b/crates/clash-server/src/lobby/lobby_handle.rs
@@ -75,7 +75,7 @@ impl LobbyHandle {
             id: self.player_id,
         };
         self.execute(msg, rx).await.map(|recv| {
-            log::info!(
+            tracing::info!(
                 "Player {:#X} has joined lobby {:#X}",
                 self.player_id,
                 self.lobby_id,

--- a/crates/clash-server/src/lobby/lobby_handle.rs
+++ b/crates/clash-server/src/lobby/lobby_handle.rs
@@ -17,11 +17,11 @@ pub struct LobbyHandleProvider {
 }
 
 impl LobbyHandleProvider {
-    pub fn get_handle(&self, player_id: PlayerId) -> LobbyHandle {
+    pub fn get_handle(&self, player_id: impl Into<PlayerId>) -> LobbyHandle {
         LobbyHandle {
             sender: self.sender.clone(),
             lobby_id: self.lobby_id,
-            player_id,
+            player_id: player_id.into(),
         }
     }
 }
@@ -76,7 +76,7 @@ impl LobbyHandle {
         };
         self.execute(msg, rx).await.map(|recv| {
             tracing::info!(
-                "Player {:#X} has joined lobby {:#X}",
+                "Player {} has joined lobby {}",
                 self.player_id,
                 self.lobby_id,
             );
@@ -147,7 +147,7 @@ impl LobbyHandle {
 #[cfg(test)]
 mod test {
     use bfbb::{Level, Spatula};
-    use clash_lib::{lobby::LobbyOptions, net::Item, player::PlayerOptions};
+    use clash_lib::{lobby::LobbyOptions, net::Item, player::PlayerOptions, PlayerId};
     use tokio::sync::mpsc;
 
     use crate::lobby::{lobby_actor::LobbyAction, LobbyError};
@@ -158,8 +158,8 @@ mod test {
         let (tx, rx) = mpsc::channel(2);
         let handle = LobbyHandle {
             sender: tx,
-            lobby_id: 0,
-            player_id: 123,
+            lobby_id: 0.into(),
+            player_id: 123.into(),
         };
         (rx, handle)
     }
@@ -168,7 +168,7 @@ mod test {
     fn lobby_provider_provides_new_handle() {
         let handle_provider = LobbyHandleProvider {
             sender: mpsc::channel(2).0,
-            lobby_id: 0,
+            lobby_id: 0.into(),
         };
 
         let handle = handle_provider.get_handle(123);
@@ -198,7 +198,7 @@ mod test {
                 m,
                 LobbyAction::StartGame {
                     respond_to: _,
-                    id: 123
+                    id: PlayerId(123),
                 }
             ));
         });
@@ -215,7 +215,7 @@ mod test {
                 m,
                 LobbyAction::AddPlayer {
                     respond_to: _,
-                    id: 123
+                    id: PlayerId(123)
                 }
             ));
         });
@@ -228,7 +228,7 @@ mod test {
         let (mut rx, handle) = setup();
         let actor = tokio::spawn(async move {
             let m = rx.recv().await.unwrap();
-            assert!(matches!(m, LobbyAction::RemovePlayer { id: 123 }));
+            assert!(matches!(m, LobbyAction::RemovePlayer { id: PlayerId(123) }));
         });
         let _ = handle.rem_player().await;
         actor.await.unwrap();
@@ -275,7 +275,7 @@ mod test {
                 m,
                 LobbyAction::SetPlayerLevel {
                     respond_to: _,
-                    id: 123,
+                    id: PlayerId(123),
                     level: Some(Level::MainMenu)
                 }
             ));
@@ -293,7 +293,7 @@ mod test {
                 m,
                 LobbyAction::PlayerCollectedItem {
                     respond_to: _,
-                    id: 123,
+                    id: PlayerId(123),
                     item: Item::Spatula(Spatula::OnTopOfThePineapple)
                 }
             ));

--- a/crates/clash-server/src/lobby/lobby_handle.rs
+++ b/crates/clash-server/src/lobby/lobby_handle.rs
@@ -39,7 +39,7 @@ impl LobbyHandle {
         msg: LobbyAction,
         rx: oneshot::Receiver<Result<T, LobbyError>>,
     ) -> Result<T, LobbyError> {
-        // Ignore first error, if there is an error, rx.await will fail aswell since it's sender
+        // Ignore first error, if there is an error, rx.await will fail as well since it's sender
         // will have been dropped
         let _ = self.sender.send(msg).await;
         rx.await.unwrap_or(Err(LobbyError::HandleInvalid))
@@ -74,14 +74,7 @@ impl LobbyHandle {
             respond_to: tx,
             id: self.player_id,
         };
-        self.execute(msg, rx).await.map(|recv| {
-            tracing::info!(
-                "Player {} has joined lobby {}",
-                self.player_id,
-                self.lobby_id,
-            );
-            recv
-        })
+        self.execute(msg, rx).await
     }
 
     // Removes a player from the lobby, if it exists, returning the number of player's remaining

--- a/crates/clash-server/src/lobby/mod.rs
+++ b/crates/clash-server/src/lobby/mod.rs
@@ -30,8 +30,5 @@ pub fn start_new_lobby(state: ServerState, id: LobbyId) -> LobbyHandleProvider {
     let actor = LobbyActor::new(state, receiver, id);
     tokio::spawn(actor.run());
 
-    LobbyHandleProvider {
-        sender,
-        lobby_id: id,
-    }
+    LobbyHandleProvider { sender }
 }

--- a/crates/clash-server/src/main.rs
+++ b/crates/clash-server/src/main.rs
@@ -4,13 +4,16 @@ mod state;
 
 use state::ServerState;
 use tokio::net::TcpListener;
+use tracing::metadata::LevelFilter;
 
 const VERSION: &str = env!("CLASH_VERSION");
 const DEFAULT_PORT: u16 = 42932;
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::DEBUG)
+        .init();
     // Builder::new()
     //     .format_level(true)
     //     .format_module_path(true)

--- a/crates/clash-server/src/main.rs
+++ b/crates/clash-server/src/main.rs
@@ -10,24 +10,25 @@ const DEFAULT_PORT: u16 = 42932;
 
 #[tokio::main]
 async fn main() {
-    env_logger::Builder::new()
-        .format_level(true)
-        .format_module_path(true)
-        .format_target(false)
-        .format_indent(Some(4))
-        .format_timestamp_secs()
-        .filter_level(log::LevelFilter::Debug)
-        .parse_env("CLASH_LOG")
-        .init();
+    tracing_subscriber::fmt().init();
+    // Builder::new()
+    //     .format_level(true)
+    //     .format_module_path(true)
+    //     .format_target(false)
+    //     .format_indent(Some(4))
+    //     .format_timestamp_secs()
+    //     .filter_level(log::LevelFilter::Debug)
+    //     .parse_env("CLASH_LOG")
+    //     .init();
 
-    log::info!("Server Version: {}", crate::VERSION);
+    tracing::info!("Server Version: {}", crate::VERSION);
 
     let port = std::env::var("PORT")
         .ok()
         .and_then(|p| p.parse().ok())
         .unwrap_or(DEFAULT_PORT);
     let listener = TcpListener::bind(("0.0.0.0", port)).await.unwrap();
-    log::info!("Listening on port {port}");
+    tracing::info!("Listening on port {port}");
 
     let state = ServerState::default();
     loop {

--- a/crates/clash-server/src/main.rs
+++ b/crates/clash-server/src/main.rs
@@ -14,15 +14,6 @@ async fn main() {
     tracing_subscriber::fmt()
         .with_max_level(LevelFilter::DEBUG)
         .init();
-    // Builder::new()
-    //     .format_level(true)
-    //     .format_module_path(true)
-    //     .format_target(false)
-    //     .format_indent(Some(4))
-    //     .format_timestamp_secs()
-    //     .filter_level(log::LevelFilter::Debug)
-    //     .parse_env("CLASH_LOG")
-    //     .init();
 
     tracing::info!("Server Version: {}", crate::VERSION);
 

--- a/crates/clash-server/src/state.rs
+++ b/crates/clash-server/src/state.rs
@@ -26,7 +26,7 @@ impl State {
     pub fn add_lobby(&mut self, state: ServerState) -> &mut LobbyHandleProvider {
         let lobby_id = self.gen_lobby_id();
         let handle = lobby::start_new_lobby(state, lobby_id);
-        log::info!("Lobby {lobby_id:#X} opened");
+        tracing::info!("Lobby {lobby_id:#X} opened");
         if let Entry::Vacant(e) = self.lobbies.entry(lobby_id) {
             return e.insert(handle);
         }

--- a/crates/clash-server/src/state.rs
+++ b/crates/clash-server/src/state.rs
@@ -26,7 +26,7 @@ impl State {
     pub fn add_lobby(&mut self, state: ServerState) -> &mut LobbyHandleProvider {
         let lobby_id = self.gen_lobby_id();
         let handle = lobby::start_new_lobby(state, lobby_id);
-        tracing::info!("Lobby {lobby_id:#X} opened");
+        tracing::info!("Lobby {lobby_id} opened");
         if let Entry::Vacant(e) = self.lobbies.entry(lobby_id) {
             return e.insert(handle);
         }
@@ -37,7 +37,7 @@ impl State {
     fn gen_player_id(&self) -> PlayerId {
         let mut player_id;
         loop {
-            player_id = thread_rng().gen();
+            player_id = thread_rng().gen::<u32>().into();
             if !self.players.contains(&player_id) {
                 break;
             };
@@ -48,7 +48,7 @@ impl State {
     fn gen_lobby_id(&self) -> LobbyId {
         let mut lobby_id;
         loop {
-            lobby_id = thread_rng().gen();
+            lobby_id = thread_rng().gen::<u32>().into();
             if !self.lobbies.contains_key(&lobby_id) {
                 break;
             };

--- a/crates/clash/Cargo.toml
+++ b/crates/clash/Cargo.toml
@@ -13,10 +13,10 @@ console = []
 anyhow.workspace = true
 bfbb = { workspace = true, features = ["game-interface"] }
 clash_lib.workspace = true
-env_logger.workspace = true
-log.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
 
 eframe = "0.19"
 image = "0.24"

--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -7,6 +7,7 @@ use bfbb::{IntoEnumIterator, Level, Spatula};
 use clash_lib::lobby::{GamePhase, NetworkedLobby};
 use clash_lib::net::{Item, LobbyMessage, Message};
 use clash_lib::PlayerId;
+use tracing::instrument;
 
 use crate::gui::handle::GuiHandle;
 use crate::net::{NetCommand, NetCommandSender};
@@ -21,6 +22,13 @@ pub struct ClashGame<I> {
     /// than searching to see if we've collected it.
     local_spat_state: HashSet<Spatula>,
     player_id: PlayerId,
+}
+
+impl<I> std::fmt::Debug for ClashGame<I> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // write!(f, "ClashGame")
+        f.debug_struct("ClashGame").finish_non_exhaustive()
+    }
 }
 
 impl<I> ClashGame<I> {
@@ -38,6 +46,7 @@ impl<I> ClashGame<I> {
 
 impl<I: InterfaceProvider> GameMode for ClashGame<I> {
     /// Process state updates from the server and report back any actions of the local player
+    #[instrument(skip_all, fields(game_mode = ?self))]
     fn update(&mut self, network_sender: &NetCommandSender) -> InterfaceResult<()> {
         self.provider.do_with_interface(|interface| {
             if interface.is_loading.get()? {

--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -206,12 +206,12 @@ mod tests {
         let mut lobby = NetworkedLobby::new(0);
         let mut player = NetworkedPlayer::new(PlayerOptions::default(), 0);
         player.current_level = Some(Level::SpongebobHouse);
-        lobby.players.insert(0, player);
+        lobby.players.insert(0.into(), player);
         lobby.game_phase = GamePhase::Playing;
 
         // Make new ClashGame and give it the default lobby
         let mut handle = GuiHandle::dummy();
-        let mut game = ClashGame::new(provider, 0);
+        let mut game = ClashGame::new(provider, 0.into());
         game.update_lobby(lobby, &mut handle);
         game
     }
@@ -293,7 +293,7 @@ mod tests {
         game.lobby.game_state.spatulas.insert(
             Spatula::CowaBungee,
             SpatulaState {
-                collection_vec: vec![1],
+                collection_vec: vec![1.into()],
             },
         );
         update_and_check(&mut game, None);

--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -7,7 +7,6 @@ use bfbb::{IntoEnumIterator, Level, Spatula};
 use clash_lib::lobby::{GamePhase, NetworkedLobby};
 use clash_lib::net::{Item, LobbyMessage, Message};
 use clash_lib::PlayerId;
-use log::info;
 
 use crate::gui::handle::GuiHandle;
 use crate::net::{NetCommand, NetCommandSender};
@@ -119,7 +118,7 @@ impl<I: InterfaceProvider> GameMode for ClashGame<I> {
                             },
                         )))
                         .unwrap();
-                    info!("Collected (from menu) {spat:?}");
+                    tracing::info!("Collected (from menu) {spat:?}");
                 }
 
                 // Detect spatula collection events
@@ -132,7 +131,7 @@ impl<I: InterfaceProvider> GameMode for ClashGame<I> {
                             },
                         )))
                         .unwrap();
-                    info!("Collected {spat:?}");
+                    tracing::info!("Collected {spat:?}");
                 }
             }
 

--- a/crates/clash/src/gui/clash.rs
+++ b/crates/clash/src/gui/clash.rs
@@ -7,6 +7,7 @@ use eframe::egui::{
 use eframe::emath::Align;
 use eframe::epaint::{Color32, FontFamily, FontId, Vec2};
 use eframe::{App, CreationContext, Frame};
+use tracing::instrument;
 
 use crate::gui::main_menu::MainMenu;
 use crate::gui::state::State;
@@ -87,6 +88,7 @@ impl Clash {
 }
 
 impl App for Clash {
+    #[instrument(skip_all)]
     fn update(&mut self, ctx: &Context, frame: &mut Frame) {
         TopBottomPanel::bottom("toolbar")
             // Margins look better with a "group" frame

--- a/crates/clash/src/gui/handle.rs
+++ b/crates/clash/src/gui/handle.rs
@@ -46,7 +46,7 @@ impl GuiHandle {
 impl GuiHandle {
     pub fn send(&mut self, msg: impl Into<GuiMessage>) {
         if let Err(e) = self.sender.send(msg.into()) {
-            log::error!("Failed to send message to GUI\n{e:?}");
+            tracing::error!("Failed to send message to GUI\n{e:?}");
         }
         self.context.request_repaint();
     }

--- a/crates/clash/src/gui/lobby/mod.rs
+++ b/crates/clash/src/gui/lobby/mod.rs
@@ -9,6 +9,7 @@ use clash_lib::PlayerId;
 use eframe::egui::{Align, Button, CentralPanel, Layout, SidePanel, Ui};
 use eframe::App;
 use itertools::intersperse;
+use tracing::instrument;
 
 use crate::game::ShutdownSender;
 use crate::gui::state::State;
@@ -94,6 +95,7 @@ impl Game {
 }
 
 impl App for Game {
+    #[instrument(skip_all)]
     fn update(&mut self, ctx: &eframe::egui::Context, _frame: &mut eframe::Frame) {
         // Receive gamestate updates
         while let Ok(msg) = self.lobby_data.gui_receiver.try_recv() {

--- a/crates/clash/src/gui/lobby/mod.rs
+++ b/crates/clash/src/gui/lobby/mod.rs
@@ -212,7 +212,9 @@ impl Game {
                 })
                 .enabled(self.is_host),
             );
-        });
+        })
+        .header_response
+        .on_hover_text("Options that may be revised or removed in the future.");
 
         if let Cow::Owned(options) = updated_options {
             self.lobby_data

--- a/crates/clash/src/gui/lobby/mod.rs
+++ b/crates/clash/src/gui/lobby/mod.rs
@@ -78,7 +78,7 @@ impl Game {
             state,
             lobby_data,
             lobby: NetworkedLobby::new(0),
-            local_player_id: 0,
+            local_player_id: 0.into(),
             is_host: false,
             lab_door_cost: ValText::with_validator(|text| {
                 text.parse::<u8>().ok().filter(|&n| n > 0 && n <= 82)
@@ -152,7 +152,7 @@ impl App for Game {
                         .on_hover_text("Copy Lobby ID to Clipboard")
                         .clicked()
                     {
-                        ctx.output().copied_text = format!("{:X}", self.lobby.lobby_id);
+                        ctx.output().copied_text = format!("{:X}", self.lobby.lobby_id.0);
                     }
                     if ui.button("Leave").clicked() {
                         self.state.change_app(MainMenu::new(self.state.clone()));

--- a/crates/clash/src/gui/main_menu.rs
+++ b/crates/clash/src/gui/main_menu.rs
@@ -3,6 +3,7 @@ use std::{mem::ManuallyDrop, rc::Rc};
 use clash_lib::{
     net::{LobbyMessage, Message},
     player::PlayerOptions,
+    LobbyId,
 };
 use eframe::{
     egui::{Align, Button, CentralPanel, Layout, TextEdit, TopBottomPanel},
@@ -26,7 +27,7 @@ pub struct MainMenu {
     state: Rc<State>,
     submenu: Submenu,
     player_name: String,
-    lobby_id: ValText<u32>,
+    lobby_id: ValText<LobbyId>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -45,7 +46,11 @@ impl MainMenu {
             // TODO: atm it is not strictly true that the lobby_id must be 8 digits,
             //  since it's just a random u32. When this is resolved on the server-side,
             //  we need to validate it here as well.
-            lobby_id: ValText::with_validator(|text| u32::from_str_radix(text, 16).ok()),
+            lobby_id: ValText::with_validator(|text| {
+                u32::from_str_radix(text.strip_prefix("0x").unwrap_or(text), 16)
+                    .map(|v| v.into())
+                    .ok()
+            }),
         }
     }
 }

--- a/crates/clash/src/gui/main_menu.rs
+++ b/crates/clash/src/gui/main_menu.rs
@@ -9,6 +9,7 @@ use eframe::{
     egui::{Align, Button, CentralPanel, Layout, TextEdit, TopBottomPanel},
     App,
 };
+use tracing::instrument;
 
 use crate::gui::BORDER;
 use crate::{
@@ -56,6 +57,7 @@ impl MainMenu {
 }
 
 impl App for MainMenu {
+    #[instrument(skip_all)]
     fn update(&mut self, ctx: &eframe::egui::Context, frame: &mut eframe::Frame) {
         match self.submenu {
             Submenu::Root => {

--- a/crates/clash/src/main.rs
+++ b/crates/clash/src/main.rs
@@ -12,15 +12,6 @@ mod net;
 const VERSION: &str = env!("CLASH_VERSION");
 
 fn main() {
-    // env_logger::Builder::new()
-    //     .format_level(true)
-    //     .format_module_path(true)
-    //     .format_target(false)
-    //     .format_indent(Some(4))
-    //     .format_timestamp_secs()
-    //     .filter_level(log::LevelFilter::Debug)
-    //     .parse_env("CLASH_LOG")
-    //     .init();
     tracing_subscriber::fmt()
         .with_max_level(LevelFilter::DEBUG)
         .init();

--- a/crates/clash/src/main.rs
+++ b/crates/clash/src/main.rs
@@ -3,6 +3,8 @@
     windows_subsystem = "windows"
 )]
 
+use tracing::metadata::LevelFilter;
+
 mod game;
 mod gui;
 mod net;
@@ -19,7 +21,9 @@ fn main() {
     //     .filter_level(log::LevelFilter::Debug)
     //     .parse_env("CLASH_LOG")
     //     .init();
-    tracing_subscriber::fmt().init();
+    tracing_subscriber::fmt()
+        .with_max_level(LevelFilter::DEBUG)
+        .init();
 
     // Start gui on the main thread
     gui::run();

--- a/crates/clash/src/main.rs
+++ b/crates/clash/src/main.rs
@@ -10,15 +10,16 @@ mod net;
 const VERSION: &str = env!("CLASH_VERSION");
 
 fn main() {
-    env_logger::Builder::new()
-        .format_level(true)
-        .format_module_path(true)
-        .format_target(false)
-        .format_indent(Some(4))
-        .format_timestamp_secs()
-        .filter_level(log::LevelFilter::Debug)
-        .parse_env("CLASH_LOG")
-        .init();
+    // env_logger::Builder::new()
+    //     .format_level(true)
+    //     .format_module_path(true)
+    //     .format_target(false)
+    //     .format_indent(Some(4))
+    //     .format_timestamp_secs()
+    //     .filter_level(log::LevelFilter::Debug)
+    //     .parse_env("CLASH_LOG")
+    //     .init();
+    tracing_subscriber::fmt().init();
 
     // Start gui on the main thread
     gui::run();

--- a/crates/clash/src/net.rs
+++ b/crates/clash/src/net.rs
@@ -6,6 +6,7 @@ use clash_lib::net::{
 };
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tracing::instrument;
 
 pub type NetCommandReceiver = mpsc::Receiver<NetCommand>;
 pub type NetCommandSender = mpsc::Sender<NetCommand>;
@@ -26,6 +27,7 @@ where
 }
 
 #[tokio::main]
+#[instrument(skip_all, name = "Network")]
 pub async fn run(
     mut receiver: NetCommandReceiver,
     logic_sender: Sender<Message>,
@@ -63,6 +65,7 @@ pub async fn run(
     tracing::info!("Disconnected from server.")
 }
 
+#[instrument(skip_all, name = "Network")]
 async fn recv_task(
     mut conn_rx: ConnectionRx,
     error_sender: Sender<anyhow::Error>,

--- a/crates/clash/src/net.rs
+++ b/crates/clash/src/net.rs
@@ -32,7 +32,7 @@ pub async fn run(
     error_sender: Sender<anyhow::Error>,
 ) {
     let ip = load_ip_address();
-    log::info!("Connecting to server at '{ip}'");
+    tracing::info!("Connecting to server at '{ip}'");
 
     let sock = TcpStream::connect(&ip).await.unwrap();
     let (mut conn_tx, conn_rx) = connection::from_socket(sock);
@@ -50,9 +50,9 @@ pub async fn run(
             NetCommand::Disconnect => break,
             NetCommand::Send(m) => m,
         };
-        log::debug!("Sending message {msg:#?}");
+        tracing::debug!("Sending message {msg:#?}");
         if let Err(e) = conn_tx.write_frame(msg).await {
-            log::error!("Error sending message to server. Disconnecting. {e:#?}");
+            tracing::error!("Error sending message to server. Disconnecting. {e:#?}");
             error_sender
                 .send(e.into())
                 .expect("GUI has crashed and so will we.");
@@ -60,7 +60,7 @@ pub async fn run(
         }
     }
     recv_task.abort();
-    log::info!("Disconnected from server.")
+    tracing::info!("Disconnected from server.")
 }
 
 async fn recv_task(
@@ -71,15 +71,15 @@ async fn recv_task(
     loop {
         let incoming = match conn_rx.read_frame().await {
             Ok(Some(x)) => {
-                log::debug!("Received message {x:#?}.");
+                tracing::debug!("Received message {x:#?}.");
                 x
             }
             Ok(None) => {
-                log::info!("Server closed connection. Disconnecting.");
+                tracing::info!("Server closed connection. Disconnecting.");
                 break;
             }
             Err(e) => {
-                log::error!("Error reading message from server. Disconnecting.\n{e}");
+                tracing::error!("Error reading message from server. Disconnecting.\n{e}");
                 error_sender
                     .send(e.into())
                     .expect("GUI has crashed and so will we.");
@@ -90,7 +90,7 @@ async fn recv_task(
         match incoming {
             Message::Lobby(act) => process_action(act, &logic_sender),
             m @ Message::ConnectionAccept { player_id: _ } => {
-                log::debug!("ConnectionAccept message got :)");
+                tracing::debug!("ConnectionAccept message got :)");
                 logic_sender.send(m).unwrap();
                 continue;
             }
@@ -99,14 +99,14 @@ async fn recv_task(
                 continue;
             }
             Message::Error { error } => {
-                log::error!("Error from server:\n{error}");
+                tracing::error!("Error from server:\n{error}");
                 error_sender
                     .send(error.into())
                     .expect("GUI has crashed and so will we.");
                 continue;
             }
             _ => {
-                log::error!("Invalid message received from server");
+                tracing::error!("Invalid message received from server");
                 continue;
             }
         }


### PR DESCRIPTION
This replaces `log` and `env_logger` with tokio's `tracing` and `tracing-subscriber` crates, respectively.

Other improvements:
- Implemented newtype pattern for `LobbyId` and `PlayerId`, offering greater typesafety and ensuring they are always printed in hexadecimal format, which is hard to do otherwise when they are nested inside another struct's debug output.
- 