### PR TITLE
Add GuiHandle

### DIFF
--- a/crates/clash/src/game/game_mode.rs
+++ b/crates/clash/src/game/game_mode.rs
@@ -1,7 +1,7 @@
 use bfbb::game_interface::InterfaceResult;
 use clash_lib::{lobby::NetworkedLobby, net::LobbyMessage};
 
-use crate::{gui::GuiSender, net::NetCommandSender};
+use crate::{gui::handle::GuiHandle, net::NetCommandSender};
 
 // TODO: Revisit this when new unique game modes are created.
 //  Idea is to allow game mode logic to be implemented by an arbitrary
@@ -9,7 +9,7 @@ use crate::{gui::GuiSender, net::NetCommandSender};
 pub trait GameMode {
     fn update(&mut self, network_sender: &NetCommandSender) -> InterfaceResult<()>;
 
-    fn message(&mut self, message: LobbyMessage, gui_sender: &mut GuiSender);
+    fn message(&mut self, message: LobbyMessage, gui_sender: &mut GuiHandle);
 
-    fn update_lobby(&mut self, new_lobby: NetworkedLobby, gui_sender: &mut GuiSender);
+    fn update_lobby(&mut self, new_lobby: NetworkedLobby, gui_sender: &mut GuiHandle);
 }

--- a/crates/clash/src/gui/handle.rs
+++ b/crates/clash/src/gui/handle.rs
@@ -1,0 +1,53 @@
+//! A handle for updating the GUI from other threads.
+//!
+//! This handle holds a copy of the GUI's [`Context`] and will
+//! ensure that [`Context::request_repaint`] is called after any message is sent.
+
+use clash_lib::{lobby::NetworkedLobby, PlayerId};
+use eframe::egui::Context;
+
+pub(super) type GuiReceiver = std::sync::mpsc::Receiver<GuiMessage>;
+pub(super) type GuiSender = std::sync::mpsc::Sender<GuiMessage>;
+
+pub enum GuiMessage {
+    LocalPlayer(PlayerId),
+    LobbyUpdate(NetworkedLobby),
+}
+
+impl From<PlayerId> for GuiMessage {
+    fn from(id: PlayerId) -> Self {
+        Self::LocalPlayer(id)
+    }
+}
+
+impl From<NetworkedLobby> for GuiMessage {
+    fn from(lobby: NetworkedLobby) -> Self {
+        Self::LobbyUpdate(lobby)
+    }
+}
+
+#[derive(Clone)]
+pub struct GuiHandle {
+    pub(super) context: Context,
+    pub(super) sender: GuiSender,
+}
+
+#[cfg(test)]
+impl GuiHandle {
+    pub fn dummy() -> Self {
+        let (sender, _) = std::sync::mpsc::channel();
+        Self {
+            context: Context::default(),
+            sender,
+        }
+    }
+}
+
+impl GuiHandle {
+    pub fn send(&mut self, msg: impl Into<GuiMessage>) {
+        if let Err(e) = self.sender.send(msg.into()) {
+            log::error!("Failed to send message to GUI\n{e:?}");
+        }
+        self.context.request_repaint();
+    }
+}

--- a/crates/clash/src/gui/main_menu.rs
+++ b/crates/clash/src/gui/main_menu.rs
@@ -17,6 +17,7 @@ use crate::{
 };
 
 use super::{
+    handle::GuiHandle,
     lobby::{Game, LobbyData},
     val_text::ValText,
 };
@@ -167,6 +168,10 @@ impl MainMenu {
 
         // Start Game Thread
         let (gui_sender, gui_receiver) = std::sync::mpsc::channel();
+        let gui_handle = GuiHandle {
+            context: gui_ctx,
+            sender: gui_sender,
+        };
         let (game_shutdown, shutdown_receiver) = tokio::sync::oneshot::channel();
         let game_thread = {
             let network_sender = network_sender.clone();
@@ -174,8 +179,7 @@ impl MainMenu {
                 .name("Logic".into())
                 .spawn(move || {
                     game::start_game(
-                        gui_sender,
-                        gui_ctx,
+                        gui_handle,
                         network_sender,
                         logic_receiver,
                         shutdown_receiver,

--- a/crates/clash/src/gui/mod.rs
+++ b/crates/clash/src/gui/mod.rs
@@ -1,4 +1,3 @@
-use clash_lib::{lobby::NetworkedLobby, PlayerId};
 use eframe::egui::{Response, Ui, Widget, WidgetText};
 use eframe::{run_native, IconData, NativeOptions};
 
@@ -7,14 +6,12 @@ use self::option_editor::OptionEditor;
 
 mod arc;
 mod clash;
+pub mod handle;
 mod lobby;
 mod main_menu;
 mod option_editor;
 mod state;
 mod val_text;
-
-pub type GuiReceiver = std::sync::mpsc::Receiver<(PlayerId, NetworkedLobby)>;
-pub type GuiSender = std::sync::mpsc::Sender<(PlayerId, NetworkedLobby)>;
 
 const BORDER: f32 = 32.;
 const PADDING: f32 = 8.;


### PR DESCRIPTION
#106 inadvertently broke the GUI updating when a new lobby is received by breaking uplifting that message type out of the `LobbyMessage` enum. This fixes the problem with a much cleaner and more robust `GuiHandle` that manages the `Context` and sender. We should probably do this for the network thread as well. Handling raw channels is difficult to maintain.