### PR TITLE
Basic end-game screen

### DIFF
--- a/crates/clash-lib/src/game_state.rs
+++ b/crates/clash-lib/src/game_state.rs
@@ -25,7 +25,7 @@ impl Default for GameState {
 }
 
 impl GameState {
-    pub fn reset_state(&mut self) {
+    pub fn reset(&mut self) {
         self.spatulas.clear();
     }
 }

--- a/crates/clash-lib/src/net/message.rs
+++ b/crates/clash-lib/src/net/message.rs
@@ -27,6 +27,7 @@ impl From<LobbyMessage> for Message {
 pub enum LobbyMessage {
     PlayerOptions { options: PlayerOptions },
     PlayerCanStart(bool),
+    ResetLobby,
     GameBegin,
     GameEnd,
     GameOptions { options: LobbyOptions },

--- a/crates/clash-lib/src/player.rs
+++ b/crates/clash-lib/src/player.rs
@@ -37,7 +37,7 @@ impl NetworkedPlayer {
         }
     }
 
-    pub fn reset_state(&mut self) {
+    pub fn reset(&mut self) {
         self.score = 0;
     }
 }

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -224,6 +224,9 @@ impl Client {
             LobbyMessage::PlayerCanStart(val) => {
                 self.lobby_handle.set_player_can_start(val).await?;
             }
+            LobbyMessage::ResetLobby => {
+                self.lobby_handle.reset_lobby().await?;
+            }
             LobbyMessage::GameOptions { options } => {
                 self.lobby_handle.set_game_options(options).await?;
             }

--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -155,6 +155,7 @@ impl<I: InterfaceProvider> GameMode for ClashGame<I> {
                     .expect("GUI has crashed and so will we");
             }
             // We're not yet doing partial updates
+            LobbyMessage::ResetLobby => todo!(),
             LobbyMessage::PlayerOptions { options: _ } => todo!(),
             LobbyMessage::GameOptions { options: _ } => todo!(),
             LobbyMessage::GameEnd => todo!(),

--- a/crates/clash/src/net.rs
+++ b/crates/clash/src/net.rs
@@ -118,7 +118,8 @@ fn process_action(action: LobbyMessage, logic_sender: &Sender<Message>) {
         LobbyMessage::GameEnd => {
             // This message isn't supposed to do anything until the GUI gets updated.
         }
-        // We aren't yet doing partial
+        // We aren't yet doing partial updates
+        LobbyMessage::ResetLobby => todo!(),
         LobbyMessage::PlayerOptions { options: _ } => todo!(),
         LobbyMessage::PlayerCanStart(_) => todo!(),
         LobbyMessage::GameOptions { options: _ } => todo!(),


### PR DESCRIPTION
This Closes #74 
--

![image](https://user-images.githubusercontent.com/3579314/200160936-93f172b5-66e4-444e-bc18-a73088e77028.png)

This implements the basic functionality needed for an end-screen. Most of the work is on the server-side here to handle the `Finished` state properly. The UI here is super basic with only a winner and a reset button added. (This reset button should be added to the `Playing` screen as well but we need to figure out how the UI should look first because the buttons will be taking up too much space as-is).