### PR TITLE
Tune release workflow behavior

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,5 @@ jobs:
           files: |
             target/release/clash${{ (startsWith(matrix.os, 'windows') && '.exe') || '' }}
             target/release/clash-server${{ (startsWith(matrix.os, 'windows') && '.exe') || '' }}
-          prerelease: ${{ startsWith(github.ref_name, 'v0.') }}
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          draft: true


### PR DESCRIPTION
* only trigger on semver match for tag name
* mark as prerelease if semver contains '-' character
* Create release as draft to act as a manual approval