### PR TITLE
Prevent sending the same collection message twice

### DIFF
--- a/crates/clash/src/game/clash_game.rs
+++ b/crates/clash/src/game/clash_game.rs
@@ -129,9 +129,8 @@ impl<I: InterfaceProvider> GameMode for ClashGame<I> {
                         .unwrap();
                     tracing::info!("Collected (from menu) {spat:?}");
                 }
-
                 // Detect spatula collection events
-                if interface.is_spatula_being_collected(spat, local_player.current_level)? {
+                else if interface.is_spatula_being_collected(spat, local_player.current_level)? {
                     self.local_spat_state.insert(spat);
                     network_sender
                         .try_send(NetCommand::Send(Message::Lobby(


### PR DESCRIPTION
This fixes the Kelp Cage error.

Kelp Cage actually sets the menu counter at the same time as when you first touch the spatula (only spatula that does this afaik). This allowed our logic to detect both the entity and menu on the same update tick, before updating our local state to start skipping that spatula.