### PR TITLE
Implement basic spectator mode

### DIFF
--- a/crates/clash-lib/src/net/message.rs
+++ b/crates/clash-lib/src/net/message.rs
@@ -13,7 +13,7 @@ pub enum Message {
     Version { version: String },
     ConnectionAccept { player_id: PlayerId },
     GameHost,
-    GameJoin { lobby_id: LobbyId },
+    GameJoin { lobby_id: LobbyId, spectate: bool },
     Lobby(LobbyMessage),
     GameLobbyInfo { lobby: NetworkedLobby },
 }

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -47,31 +47,18 @@ impl ConnectingClient {
         }
     }
 
-    async fn handshake(mut self) -> Option<Client> {
-        let lobby_handle = match self.try_handshake().await {
-            Ok(it) => it,
+    async fn handshake(mut self) -> Option<ConnectedClient> {
+        match self.try_handshake().await {
+            Ok(it) => Some(it.construct(self)),
             Err(error) => {
+                tracing::error!(%error);
                 let _ = self.conn_tx.write_frame(Message::Error { error }).await;
                 return None;
             }
-        };
-
-        let lobby_recv = match lobby_handle.join_lobby().await {
-            Ok(it) => it,
-            Err(error) => {
-                let _ = self
-                    .conn_tx
-                    .write_frame(Message::Error {
-                        error: ProtocolError::Message(error.to_string()),
-                    })
-                    .await;
-                return None;
-            }
-        };
-        Some(Client::from_connecting(self, lobby_handle, lobby_recv))
+        }
     }
 
-    async fn try_handshake(&mut self) -> Result<LobbyHandle, ProtocolError> {
+    async fn try_handshake(&mut self) -> Result<ClientConstructor, ProtocolError> {
         let version = match self.conn_rx.read_frame().await? {
             Some(Message::Version { version }) => version,
             Some(_) => return Err(ProtocolError::InvalidMessage),
@@ -99,21 +86,80 @@ impl ConnectingClient {
                 state.players.insert(self.player_id);
                 state.open_lobby(self.state.clone(), self.player_id)
             }
-            Some(Message::GameJoin { lobby_id }) => {
-                let state = &mut *self.state.lock().unwrap();
-                state.players.insert(self.player_id);
-                state
-                    .lobbies
-                    .get_mut(&lobby_id)
-                    .ok_or(ProtocolError::InvalidLobbyId(lobby_id))?
-                    .get_handle(self.player_id)
-                    .ok_or(ProtocolError::InvalidLobbyId(lobby_id))?
+            Some(Message::GameJoin { lobby_id, spectate }) => {
+                let handle_provider = {
+                    let state = &mut *self.state.lock().unwrap();
+                    state.players.insert(self.player_id);
+                    state
+                        .lobbies
+                        .get_mut(&lobby_id)
+                        .ok_or(ProtocolError::InvalidLobbyId(lobby_id))?
+                        .clone()
+                };
+
+                if spectate {
+                    let recv = handle_provider.spectate().await?;
+                    return Ok(ClientConstructor::Spectator(recv));
+                } else {
+                    handle_provider.get_handle(self.player_id)?
+                }
             }
             Some(_) => return Err(ProtocolError::InvalidMessage),
             None => return Err(ProtocolError::Disconnected),
         };
 
-        Ok(lobby_handle)
+        let lobby_recv = lobby_handle
+            .join_lobby()
+            .await
+            .map_err(|err| ProtocolError::Message(err.to_string()))?;
+        Ok(ClientConstructor::Player(lobby_handle, lobby_recv))
+    }
+}
+
+/// Our [`ConnectedClient`] constructors need to take ownership of a [`ConnectedClient`].
+/// This allows us to return what kind of client to construct from `try_handshake` to the caller,
+/// since the caller needs to retain ownership of `self` for error reporting to the client.
+enum ClientConstructor {
+    Player(LobbyHandle, broadcast::Receiver<Message>),
+    Spectator(broadcast::Receiver<Message>),
+}
+
+impl ClientConstructor {
+    fn construct(self, client: ConnectingClient) -> ConnectedClient {
+        match self {
+            ClientConstructor::Player(lobby_handle, lobby_recv) => {
+                Client::from_connecting(client, lobby_handle, lobby_recv).into()
+            }
+            ClientConstructor::Spectator(lobby_recv) => {
+                SpectatingClient::from_connecting(client, lobby_recv).into()
+            }
+        }
+    }
+}
+
+enum ConnectedClient {
+    Player(Client),
+    Spectator(SpectatingClient),
+}
+
+impl Into<ConnectedClient> for Client {
+    fn into(self) -> ConnectedClient {
+        ConnectedClient::Player(self)
+    }
+}
+
+impl Into<ConnectedClient> for SpectatingClient {
+    fn into(self) -> ConnectedClient {
+        ConnectedClient::Spectator(self)
+    }
+}
+
+impl ConnectedClient {
+    async fn run(self) {
+        match self {
+            ConnectedClient::Player(c) => c.run().await,
+            ConnectedClient::Spectator(c) => c.run().await,
+        }
     }
 }
 
@@ -238,6 +284,72 @@ impl Drop for Client {
         // Since we are currently dropping ourself, self.lobby_handle will never be used again.
         let lobby_handle = unsafe { ManuallyDrop::take(&mut self.lobby_handle) };
         tokio::spawn(async move { lobby_handle.rem_player().await });
+
+        // This will crash the program if we're dropping due to a previous panic caused by a poisoned lock,
+        // and that's fine for now.
+        let state = &mut *self.state.lock().unwrap();
+        state.players.remove(&self.player_id);
+    }
+}
+
+struct SpectatingClient {
+    state: ServerState,
+    player_id: PlayerId,
+    conn_rx: ConnectionRx,
+    local_tx: mpsc::Sender<Message>,
+    task_handle: JoinHandle<()>,
+}
+
+impl SpectatingClient {
+    pub fn from_connecting(
+        client: ConnectingClient,
+        lobby_recv: broadcast::Receiver<Message>,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(64);
+        let task_handle = tokio::spawn(send_task(client.conn_tx, lobby_recv, rx));
+
+        Self {
+            state: client.state,
+            player_id: client.player_id,
+            conn_rx: client.conn_rx,
+            local_tx: tx,
+            task_handle,
+        }
+    }
+
+    /// Takes ownership of self to guarantee that client will be dropped when it's
+    /// message loop ends
+    #[instrument(skip_all, fields(player_id = %self.player_id))]
+    pub async fn run(mut self) {
+        loop {
+            match self.conn_rx.read_frame().await {
+                // Spectators should never send a message again after joining
+                Ok(Some(m)) => {
+                    tracing::error!("Invalid message received: {m:?}");
+                    let _ = self
+                        .local_tx
+                        .send(Message::Error {
+                            error: ProtocolError::InvalidMessage,
+                        })
+                        .await;
+                    continue;
+                }
+                Ok(None) => {
+                    break;
+                }
+                Err(e) => {
+                    tracing::error!("Error reading message, Closing connection\n{e:?}",);
+                    break;
+                }
+            };
+        }
+        tracing::info!("Player disconnected");
+    }
+}
+
+impl Drop for SpectatingClient {
+    fn drop(&mut self) {
+        self.task_handle.abort();
 
         // This will crash the program if we're dropping due to a previous panic caused by a poisoned lock,
         // and that's fine for now.

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -97,9 +97,7 @@ impl ConnectingClient {
             Some(Message::GameHost) => {
                 let state = &mut *self.state.lock().unwrap();
                 state.players.insert(self.player_id);
-                state
-                    .add_lobby(self.state.clone())
-                    .get_handle(self.player_id)
+                state.open_lobby(self.state.clone(), self.player_id)
             }
             Some(Message::GameJoin { lobby_id }) => {
                 let state = &mut *self.state.lock().unwrap();
@@ -109,6 +107,7 @@ impl ConnectingClient {
                     .get_mut(&lobby_id)
                     .ok_or(ProtocolError::InvalidLobbyId(lobby_id))?
                     .get_handle(self.player_id)
+                    .ok_or(ProtocolError::InvalidLobbyId(lobby_id))?
             }
             Some(_) => return Err(ProtocolError::InvalidMessage),
             None => return Err(ProtocolError::Disconnected),

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -53,7 +53,7 @@ impl ConnectingClient {
             Err(error) => {
                 tracing::error!(%error);
                 let _ = self.conn_tx.write_frame(Message::Error { error }).await;
-                return None;
+                None
             }
         }
     }
@@ -142,15 +142,15 @@ enum ConnectedClient {
     Spectator(SpectatingClient),
 }
 
-impl Into<ConnectedClient> for Client {
-    fn into(self) -> ConnectedClient {
-        ConnectedClient::Player(self)
+impl From<Client> for ConnectedClient {
+    fn from(val: Client) -> Self {
+        ConnectedClient::Player(val)
     }
 }
 
-impl Into<ConnectedClient> for SpectatingClient {
-    fn into(self) -> ConnectedClient {
-        ConnectedClient::Spectator(self)
+impl From<SpectatingClient> for ConnectedClient {
+    fn from(val: SpectatingClient) -> Self {
+        ConnectedClient::Spectator(val)
     }
 }
 

--- a/crates/clash-server/src/lobby/lobby_actor.rs
+++ b/crates/clash-server/src/lobby/lobby_actor.rs
@@ -725,7 +725,7 @@ mod test {
             let handle = LobbyHandleProvider {
                 sender: tx.downgrade(),
             }
-            .get_handle(0);
+            .into_handle(0);
             actor.add_player(0.into()).unwrap();
             (actor, handle)
         };

--- a/crates/clash-server/src/lobby/lobby_actor.rs
+++ b/crates/clash-server/src/lobby/lobby_actor.rs
@@ -32,6 +32,9 @@ pub enum LobbyAction {
         respond_to: oneshot::Sender<LobbyResult<broadcast::Receiver<Message>>>,
         id: PlayerId,
     },
+    AddSpectator {
+        respond_to: oneshot::Sender<broadcast::Receiver<Message>>,
+    },
     RemovePlayer {
         id: PlayerId,
     },
@@ -92,6 +95,9 @@ impl LobbyActor {
                 }
                 LobbyAction::AddPlayer { respond_to, id } => {
                     let _ = respond_to.send(self.add_player(id));
+                }
+                LobbyAction::AddSpectator { respond_to } => {
+                    let _ = respond_to.send(self.add_spectator());
                 }
                 LobbyAction::RemovePlayer { id } => self.rem_player(id),
                 LobbyAction::SetPlayerOptions {
@@ -236,6 +242,20 @@ impl LobbyActor {
         self.send_lobby();
 
         Ok(recv)
+    }
+
+    /// Adds a spectator to a lobby.
+    ///
+    /// Currently this does not modify the underlying lobby at all. A simple subscription to the
+    /// broadcast channel is all that happens here, causing the spectator to receive lobby events.
+    /// In the future lobbies may need to become aware of spectators. (Allow/Deny spectating, show
+    /// spectator counts/names, etc.)
+    #[instrument(skip(self))]
+    fn add_spectator(&mut self) -> broadcast::Receiver<Message> {
+        let recv = self.sender.subscribe();
+        tracing::info!("Player is now spectating");
+        self.send_lobby();
+        recv
     }
 
     /// Removes a player from the lobby. If the host is removed, a new host is assigned randomly.
@@ -447,6 +467,15 @@ mod test {
             lobby.add_player(6.into()),
             Err(LobbyError::LobbyFull)
         ));
+    }
+
+    #[test]
+    fn add_spectator() {
+        let mut lobby = setup();
+
+        // Adding a spectator does not add a new player.
+        lobby.add_spectator();
+        assert!(lobby.shared.players.is_empty());
     }
 
     #[test]

--- a/crates/clash-server/src/lobby/lobby_handle.rs
+++ b/crates/clash-server/src/lobby/lobby_handle.rs
@@ -10,13 +10,13 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use super::LobbyError;
 use super::{lobby_actor::LobbyAction, LobbyResult};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct LobbyHandleProvider {
     pub(super) sender: mpsc::WeakSender<LobbyAction>,
 }
 
 impl LobbyHandleProvider {
-    pub fn get_handle(&self, player_id: impl Into<PlayerId>) -> LobbyResult<LobbyHandle> {
+    pub fn into_handle(self, player_id: impl Into<PlayerId>) -> LobbyResult<LobbyHandle> {
         Ok(LobbyHandle {
             sender: self.sender.upgrade().ok_or(LobbyError::HandleInvalid)?,
             player_id: player_id.into(),
@@ -33,7 +33,7 @@ impl LobbyHandleProvider {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct LobbyHandle {
     pub(super) sender: mpsc::Sender<LobbyAction>,
     pub(super) player_id: PlayerId,
@@ -169,7 +169,7 @@ mod test {
             sender: tx.downgrade(),
         };
 
-        let handle = handle_provider.get_handle(123).unwrap();
+        let handle = handle_provider.into_handle(123).unwrap();
         assert_eq!(handle.player_id, 123);
     }
 

--- a/crates/clash-server/src/lobby/mod.rs
+++ b/crates/clash-server/src/lobby/mod.rs
@@ -1,4 +1,4 @@
-use clash_lib::{LobbyId, PlayerId};
+use clash_lib::{net::ProtocolError, LobbyId, PlayerId};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
@@ -24,6 +24,12 @@ pub enum LobbyError {
     NeedsHost,
     #[error("The Lobby Handle is no longer connected to a lobby.")]
     HandleInvalid,
+}
+
+impl From<LobbyError> for ProtocolError {
+    fn from(v: LobbyError) -> Self {
+        Self::Message(v.to_string())
+    }
 }
 
 pub type LobbyResult<T> = Result<T, LobbyError>;

--- a/crates/clash-server/src/lobby/mod.rs
+++ b/crates/clash-server/src/lobby/mod.rs
@@ -4,7 +4,10 @@ use tokio::sync::mpsc;
 
 use crate::state::ServerState;
 
-use self::{lobby_actor::LobbyActor, lobby_handle::LobbyHandleProvider};
+use self::{
+    lobby_actor::LobbyActor,
+    lobby_handle::{LobbyHandle, LobbyHandleProvider},
+};
 
 mod lobby_actor;
 pub mod lobby_handle;
@@ -25,10 +28,24 @@ pub enum LobbyError {
 
 pub type LobbyResult<T> = Result<T, LobbyError>;
 
-pub fn start_new_lobby(state: ServerState, id: LobbyId) -> LobbyHandleProvider {
+pub fn start_new_lobby(
+    state: ServerState,
+    id: LobbyId,
+    host_id: PlayerId,
+) -> (LobbyHandleProvider, LobbyHandle) {
     let (sender, receiver) = mpsc::channel(64);
+    let weak_sender = sender.downgrade();
     let actor = LobbyActor::new(state, receiver, id);
+    let handle = LobbyHandle {
+        sender,
+        player_id: host_id,
+    };
     tokio::spawn(actor.run());
 
-    LobbyHandleProvider { sender }
+    (
+        LobbyHandleProvider {
+            sender: weak_sender,
+        },
+        handle,
+    )
 }

--- a/crates/clash-server/src/state.rs
+++ b/crates/clash-server/src/state.rs
@@ -11,7 +11,7 @@ pub type ServerState = Arc<Mutex<State>>;
 #[derive(Debug, Default)]
 pub struct State {
     pub players: HashSet<PlayerId>,
-    pub lobbies: HashMap<LobbyId, Arc<LobbyHandleProvider>>,
+    pub lobbies: HashMap<LobbyId, LobbyHandleProvider>,
 }
 
 impl State {
@@ -30,7 +30,7 @@ impl State {
         let lobby_id = self.gen_lobby_id();
         let (handle_provider, handle) = lobby::start_new_lobby(state, lobby_id, host_id);
         tracing::info!("Lobby {lobby_id} opened");
-        self.lobbies.insert(lobby_id, Arc::new(handle_provider));
+        self.lobbies.insert(lobby_id, handle_provider);
         handle
     }
 

--- a/crates/clash-server/src/state.rs
+++ b/crates/clash-server/src/state.rs
@@ -11,7 +11,7 @@ pub type ServerState = Arc<Mutex<State>>;
 #[derive(Debug, Default)]
 pub struct State {
     pub players: HashSet<PlayerId>,
-    pub lobbies: HashMap<LobbyId, LobbyHandleProvider>,
+    pub lobbies: HashMap<LobbyId, Arc<LobbyHandleProvider>>,
 }
 
 impl State {
@@ -30,7 +30,7 @@ impl State {
         let lobby_id = self.gen_lobby_id();
         let (handle_provider, handle) = lobby::start_new_lobby(state, lobby_id, host_id);
         tracing::info!("Lobby {lobby_id} opened");
-        self.lobbies.insert(lobby_id, handle_provider);
+        self.lobbies.insert(lobby_id, Arc::new(handle_provider));
         handle
     }
 

--- a/crates/clash/src/gui/lobby/mod.rs
+++ b/crates/clash/src/gui/lobby/mod.rs
@@ -50,15 +50,18 @@ impl Drop for LobbyData {
                 ManuallyDrop::take(&mut self.game_thread),
             )
         };
-        let _ = crate::net::spawn_promise(async move {
-            game_shutdown
-                .send(())
-                .expect("Failed to signal game-logic thread to shutdown");
+        // We want to await the network task to avoid a situation where the network fails to shutdown,
+        // but the app seemingly continues as normal
+        let stop_net = crate::net::spawn_promise(async move {
             network_thread.await.expect("Network thread failed to join");
-            game_thread
-                .join()
-                .expect("Game logic thread failed to join");
         });
+        game_shutdown
+            .send(())
+            .expect("Failed to signal game-logic thread to shutdown");
+        game_thread
+            .join()
+            .expect("Game logic thread failed to join");
+        stop_net.block_until_ready();
     }
 }
 

--- a/crates/clash/src/gui/main_menu.rs
+++ b/crates/clash/src/gui/main_menu.rs
@@ -200,7 +200,7 @@ impl MainMenu {
     fn spawn_net(&self, gui_ctx: eframe::egui::Context, spectator: bool) -> LobbyData {
         let (network_sender, network_receiver) = tokio::sync::mpsc::channel::<NetCommand>(32);
         let (logic_sender, logic_receiver) = std::sync::mpsc::channel::<Message>();
-        let network_thread = net::run(
+        let network_thread = net::spawn(
             network_receiver,
             logic_sender,
             self.state.error_sender.clone(),

--- a/crates/clash/src/gui/main_menu.rs
+++ b/crates/clash/src/gui/main_menu.rs
@@ -200,12 +200,11 @@ impl MainMenu {
     fn spawn_net(&self, gui_ctx: eframe::egui::Context) -> LobbyData {
         let (network_sender, network_receiver) = tokio::sync::mpsc::channel::<NetCommand>(32);
         let (logic_sender, logic_receiver) = std::sync::mpsc::channel::<Message>();
-        // Create a new thread and start a tokio runtime on it for talking to the server
-        let error_sender = self.state.error_sender.clone();
-        let network_thread = std::thread::Builder::new()
-            .name("Network".into())
-            .spawn(move || net::run(network_receiver, logic_sender, error_sender))
-            .expect("Couldn't start network thread.");
+        let network_thread = net::run(
+            network_receiver,
+            logic_sender,
+            self.state.error_sender.clone(),
+        );
 
         // Start Game Thread
         let (gui_sender, gui_receiver) = std::sync::mpsc::channel();

--- a/crates/clash/src/net.rs
+++ b/crates/clash/src/net.rs
@@ -77,7 +77,7 @@ where
 }
 
 /// Entry point to the network. Spawns the network task on the preconfigured [`Runtime`]
-pub fn run(
+pub fn spawn(
     receiver: NetCommandReceiver,
     logic_sender: Sender<Message>,
     error_sender: Sender<anyhow::Error>,


### PR DESCRIPTION
This closes #124 

This is pretty much just the minimum required for usecases like tournament/event casting.

UI will need to be revisited at some point and lobbies will need to be able to allow/disallow spectating and track active spectators at some point.