### PR TITLE
Improve ServerState ergonomics and cleanup client connection/disconnection logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330223a1aecc308757b9926e9391c9b47f8ef2dbd8aea9df88312aea18c5e8d6"
 
 [[package]]
+name = "abort-on-drop"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd6d700ad9af641490c1f7d67980d2de4d1433016e5b12f819448d3c832142a"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "accesskit"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +453,7 @@ dependencies = [
 name = "clash-server"
 version = "0.2.0-rc.2"
 dependencies = [
+ "abort-on-drop",
  "anyhow",
  "bfbb",
  "clash_lib",

--- a/crates/clash-server/Cargo.toml
+++ b/crates/clash-server/Cargo.toml
@@ -16,6 +16,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 rand = "0.8"
+abort-on-drop = "0.2.2"
 
 [build-dependencies]
 anyhow.workspace = true

--- a/crates/clash-server/src/client.rs
+++ b/crates/clash-server/src/client.rs
@@ -166,7 +166,6 @@ async fn send_task(
 
 /// Used to represent a client who is in a lobby.
 struct PlayerClient {
-    state: ServerState,
     player_id: OwnedId<PlayerId>,
     conn_rx: ConnectionRx,
     local_tx: mpsc::Sender<Message>,
@@ -185,7 +184,6 @@ impl PlayerClient {
         let task_handle = tokio::spawn(send_task(client.conn_tx, lobby_recv, rx)).into();
 
         PlayerClient {
-            state: client.state,
             player_id: client.player_id,
             conn_rx: client.conn_rx,
             local_tx: tx,
@@ -260,7 +258,6 @@ impl PlayerClient {
 
 // TODO: Abstract client types and deduplicate code.
 struct SpectatingClient {
-    state: ServerState,
     player_id: OwnedId<PlayerId>,
     conn_rx: ConnectionRx,
     local_tx: mpsc::Sender<Message>,
@@ -276,7 +273,6 @@ impl SpectatingClient {
         let task_handle = tokio::spawn(send_task(client.conn_tx, lobby_recv, rx)).into();
 
         Self {
-            state: client.state,
             player_id: client.player_id,
             conn_rx: client.conn_rx,
             local_tx: tx,

--- a/crates/clash-server/src/lobby/mod.rs
+++ b/crates/clash-server/src/lobby/mod.rs
@@ -2,7 +2,7 @@ use clash_lib::{net::ProtocolError, LobbyId, PlayerId};
 use thiserror::Error;
 use tokio::sync::mpsc;
 
-use crate::state::ServerState;
+use crate::state::OwnedId;
 
 use self::{
     lobby_actor::LobbyActor,
@@ -35,13 +35,12 @@ impl From<LobbyError> for ProtocolError {
 pub type LobbyResult<T> = Result<T, LobbyError>;
 
 pub fn start_new_lobby(
-    state: ServerState,
-    id: LobbyId,
+    id: OwnedId<LobbyId>,
     host_id: PlayerId,
 ) -> (LobbyHandleProvider, LobbyHandle) {
     let (sender, receiver) = mpsc::channel(64);
     let weak_sender = sender.downgrade();
-    let actor = LobbyActor::new(state, receiver, id);
+    let actor = LobbyActor::new(receiver, id);
     let handle = LobbyHandle {
         sender,
         player_id: host_id,

--- a/crates/clash-server/src/state.rs
+++ b/crates/clash-server/src/state.rs
@@ -1,37 +1,64 @@
+use clash_lib::net::ProtocolError;
 use clash_lib::{LobbyId, PlayerId};
 use rand::{thread_rng, Rng};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::fmt::Display;
+use std::ops::Deref;
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use crate::lobby;
 use crate::lobby::lobby_handle::{LobbyHandle, LobbyHandleProvider};
 
-pub type ServerState = Arc<Mutex<State>>;
-
-#[derive(Debug, Default)]
-pub struct State {
-    pub players: HashSet<PlayerId>,
-    pub lobbies: HashMap<LobbyId, LobbyHandleProvider>,
+#[derive(Clone, Debug, Default)]
+pub struct ServerState {
+    players: Arc<Mutex<HashSet<PlayerId>>>,
+    lobbies: Arc<Mutex<HashMap<LobbyId, LobbyHandleProvider>>>,
 }
 
-impl State {
-    pub fn add_player(&mut self) -> PlayerId {
+impl ServerState {
+    pub fn add_player(&self) -> OwnedId<PlayerId> {
         let player_id = self.gen_player_id();
-        self.players.insert(player_id);
-        player_id
+        self.players().insert(player_id);
+        OwnedId::<PlayerId>::new(self.clone(), player_id)
     }
 
     /// Open a new lobby with the player represented by `host_id` as the only player.
     ///
     /// This will add a [`LobbyHandleProvider`] to [`ServerState`]'s lobby list and return a
     /// concrete `LobbyHandle` for the player who opened the lobby.
-    // TODO: Would be nice to not have to pass in a clone of ServerState here
-    pub fn open_lobby(&mut self, state: ServerState, host_id: PlayerId) -> LobbyHandle {
+    pub fn open_lobby(&self, host_id: PlayerId) -> LobbyHandle {
         let lobby_id = self.gen_lobby_id();
-        let (handle_provider, handle) = lobby::start_new_lobby(state, lobby_id, host_id);
+        let (handle_provider, handle) =
+            lobby::start_new_lobby(OwnedId::<LobbyId>::new(self.clone(), lobby_id), host_id);
         tracing::info!("Lobby {lobby_id} opened");
-        self.lobbies.insert(lobby_id, handle_provider);
+        self.lobbies().insert(lobby_id, handle_provider);
         handle
+    }
+
+    /// Get a [`LobbyHandleProvider`] instance for the specified `lobby_id`
+    ///
+    /// # Errors
+    ///
+    /// Will return a [`ProtocolError::InvalidLobbyId`] if the given lobby id does
+    /// not correspond to an open lobby.
+    pub fn get_lobby_handle_provider(
+        &self,
+        lobby_id: LobbyId,
+    ) -> Result<LobbyHandleProvider, ProtocolError> {
+        let provider = self
+            .lobbies()
+            .get_mut(&lobby_id)
+            .ok_or(ProtocolError::InvalidLobbyId(lobby_id))?
+            .clone();
+        Ok(provider)
+    }
+
+    fn players(&self) -> MutexGuard<HashSet<PlayerId>> {
+        self.players.lock().unwrap()
+    }
+
+    fn lobbies(&self) -> MutexGuard<HashMap<LobbyId, LobbyHandleProvider>> {
+        self.lobbies.lock().unwrap()
     }
 
     // TODO: dedupe this.
@@ -39,7 +66,7 @@ impl State {
         let mut player_id;
         loop {
             player_id = thread_rng().gen::<u32>().into();
-            if !self.players.contains(&player_id) {
+            if !self.players().contains(&player_id) {
                 break;
             };
         }
@@ -50,10 +77,79 @@ impl State {
         let mut lobby_id;
         loop {
             lobby_id = thread_rng().gen::<u32>().into();
-            if !self.lobbies.contains_key(&lobby_id) {
+            if !self.lobbies().contains_key(&lobby_id) {
                 break;
             };
         }
         lobby_id
+    }
+}
+
+/// Wrapper around Id types that is handed out when an Id is stored in the state
+/// and when dropped will remove that id from the state.
+#[derive(Debug)]
+pub struct OwnedId<Id: Copy> {
+    state: ServerState,
+    id: Id,
+    cleanup: fn(ServerState, Id),
+}
+
+impl<Id: Display + Copy> Display for OwnedId<Id> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.id.fmt(f)
+    }
+}
+
+/// Workaround for testing LobbyActor
+#[cfg(test)]
+impl From<LobbyId> for OwnedId<LobbyId> {
+    fn from(v: LobbyId) -> Self {
+        Self {
+            state: ServerState::default(),
+            id: v,
+            cleanup: |_, _| {},
+        }
+    }
+}
+
+impl OwnedId<PlayerId> {
+    fn new(state: ServerState, id: PlayerId) -> Self {
+        Self {
+            state,
+            id,
+            cleanup: |state, id| {
+                tracing::info!("Player disconnected");
+                state.players.lock().unwrap().remove(&id);
+            },
+        }
+    }
+}
+
+impl OwnedId<LobbyId> {
+    fn new(state: ServerState, id: LobbyId) -> Self {
+        Self {
+            state,
+            id,
+            cleanup: |state, id| {
+                tracing::info!("Closing lobby");
+                state.lobbies.lock().unwrap().remove(&id);
+            },
+        }
+    }
+}
+
+impl<Id: Copy> Deref for OwnedId<Id> {
+    type Target = Id;
+
+    fn deref(&self) -> &Self::Target {
+        &self.id
+    }
+}
+
+impl<Id: Copy> Drop for OwnedId<Id> {
+    fn drop(&mut self) {
+        // This will crash the program if we're dropping due to a previous panic caused by a poisoned lock,
+        // and that's fine for now.
+        (self.cleanup)(self.state.clone(), self.id);
     }
 }


### PR DESCRIPTION
`ServerState` is now a concrete struct that can be freely cloned and allows mutation through interior mutability. Consumers of the `ServerState` no longer have to deal with locking the state themselves. This will make improving our locking strategies in the future much easier if necessary and makes the rest of our code easier to follow.

Client drop code has been removed by moving the drop logic to individual components to reduce duplication. `ServerState` now hands out an `OwnedId` for Id types when their resource is created and automatically takes care of updating the state as appropriate when that `OwnedId` is dropped. `LobbyHandle` itself now handles removing the player from the lobby when it is dropped. the `abort-on-drop` crate adds the `ChildTask` wrapper to automatically abort the wrapped task when it's dropped.