### PR TITLE
Add settings item for overriding the server's IP address

### DIFF
--- a/crates/clash/src/net.rs
+++ b/crates/clash/src/net.rs
@@ -97,7 +97,7 @@ async fn net_task(
     let ip = load_ip_address();
     tracing::info!("Connecting to server at '{ip}'");
 
-    let addr = { SERVER_ADDRESS.lock().unwrap().clone() };
+    let addr = { *SERVER_ADDRESS.lock().unwrap() };
     let sock = TcpStream::connect(addr).await.unwrap();
     let (mut conn_tx, conn_rx) = connection::from_socket(sock);
     conn_tx


### PR DESCRIPTION
This is pretty much the last thing on list for wrapping up 0.2.0

When we decide on a longer-term hosting solution we can set things up to default to our server and do the release.